### PR TITLE
[cxbx-reloaded] Add support for the original xbox emulator Cxbx-Reloaded

### DIFF
--- a/configs/Cxbx-Reloaded/cxbx-reloaded-wrapper
+++ b/configs/Cxbx-Reloaded/cxbx-reloaded-wrapper
@@ -1,0 +1,24 @@
+#!/bin/bash
+cxbx_reloaded_exe="$(realpath "$(dirname "$0")/cxbx.exe")"
+cxbx_reloaded_bottle='cxbx-reloaded'
+args=("$@")
+i=0
+for a in "${args[@]}"
+do
+    if [[ "${a,,}" == "/load" ]] && [[ $((i+1)) -lt ${#args[@]} ]]
+    then
+        na="${args[$((i+1))]}"
+        if ! [[ "$na" =~ ^[a-zA-Z]:\\ ]]
+        then
+            # we transform the unix path to the equivalent windows path
+            na="$(realpath "$na")"
+            na="Z:${na//\//\\}"
+            args[$((i+1))]="$na"
+        fi
+    fi
+    i=$((i+1))
+done
+exec flatpak run --command="bottles-cli" com.usebottles.bottles run \
+    -b "$cxbx_reloaded_bottle" \
+    -e "$cxbx_reloaded_exe" \
+    -a "${args[*]@Q}"

--- a/configs/Cxbx-Reloaded/settings.ini
+++ b/configs/Cxbx-Reloaded/settings.ini
@@ -1,0 +1,133 @@
+[gui]
+CxbxDebugMode = 0x0
+CxbxDebugLogFile = 
+DataStorageToggle = 0x1
+DataCustomLocation = 
+RecentXbeFiles =
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+IgnoreInvalidXbeSig = false
+IgnoreInvalidXbeSec = false
+
+
+[core]
+Revision = 9
+FlagsLLE = 0x0
+KrnlDebugMode = 0x0
+KrnlDebugLogFile = 
+AllowAdminPrivilege = false
+LogLevel = 1
+LoggedModules = 0x0
+LoggedModules = 0x0
+LoggedModules = 0x0
+LogPopupTestCase = true
+LoaderExecutable = true
+
+
+[video]
+VideoResolution = Automatic (Xbox Default)
+adapter = 0x0
+Direct3DDevice = 0x0
+VSync = false
+FullScreen = false
+MaintainAspect = true
+RenderResolution = 1
+
+
+[audio]
+adapter = 00000000 0000 0000 0000 000000000000
+PCM = true
+XADPCM = true
+UnknownCodec = true
+MuteOnUnfocus = true
+
+
+[network]
+adapter_name = 
+
+
+[input-general]
+MouseAxisRange = 10
+MouseWheelRange = 80
+IgnoreKbMoUnfocus = true
+
+
+[input-port-0]
+Type = 1
+DeviceName = XInput/0/Gamepad
+ProfileName = "Steam Deck"
+TopSlot = -1
+BottomSlot = -1
+
+
+[input-port-1]
+Type = -1
+DeviceName = 
+ProfileName = """
+TopSlot = -1
+BottomSlot = -1
+
+
+[input-port-2]
+Type = -1
+DeviceName = 
+ProfileName = """
+TopSlot = -1
+BottomSlot = -1
+
+
+[input-port-3]
+Type = -1
+DeviceName = 
+ProfileName = """
+TopSlot = -1
+BottomSlot = -1
+
+
+[overlay]
+FPS = false
+HLE/LLE Stats = false
+
+
+[hack]
+DisablePixelShaders = false
+UseAllCores = true
+SkipRdtscPatching = false
+
+
+[input-profile-0]
+Type = 1
+ProfileName = "Steam Deck"
+DeviceName = XInput/0/Gamepad
+D Pad Up = Pad N
+D Pad Down = Pad S
+D Pad Left = Pad W
+D Pad Right = Pad E
+Start = Start
+Back = Back
+L Thumb = Thumb L
+R Thumb = Thumb R
+A = Button A
+B = Button B
+X = Button X
+Y = Button Y
+Black = Shoulder R
+White = Shoulder L
+L Trigger = Trigger L
+R Trigger = Trigger R
+Left Axis X+ = Left X+
+Left Axis X- = Left X-
+Left Axis Y+ = Left Y+
+Left Axis Y- = Left Y-
+Right Axis X+ = Right X+
+Right Axis X- = Right X-
+Right Axis Y+ = Right Y+
+Right Axis Y- = Right Y-
+Motor = LeftRight

--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleList>
+    <emulator name="CXBX_RELOADED">
+        <!-- Microsoft Xbox emulator Cxbx-Reloaded -->
+        <rule type="systempath">
+            <entry>cxbx-reloaded-wrapper</entry>
+        </rule>
+        <rule type="staticpath">
+            <entry>/home/deck/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper</entry>
+            <entry>/run/media/mmcblk0p1/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper</entry>
+            <entry>/var/lib/flatpak/exports/bin/cxbx-reloaded-wrapper</entry>
+            <entry>~/.local/share/flatpak/exports/bin/cxbx-reloaded-wrapper</entry>
+            <entry>~/Applications/cxbx-reloaded-wrapper</entry>
+            <entry>~/.local/bin/cxbx-reloaded-wrapper</entry>
+            <entry>~/bin/cxbx-reloaded-wrapper</entry>
+        </rule>
+    </emulator>
+</ruleList>

--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<systemList>
+    <system>
+        <name>xbox</name>
+        <fullname>Microsoft Xbox</fullname>
+        <path>%ROMPATH%/xbox</path>
+        <extension>.xbe .XBE .iso .ISO</extension>
+        <command label="Cxbx-Reloaded (Standalone)">%EMULATOR_CXBX_RELOADED% /load %ROM%</command>
+        <command label="xemu (Standalone)">%EMULATOR_XEMU% -full-screen -dvd_path %ROM%</command>
+        <platform>xbox</platform>
+        <theme>xbox</theme>
+    </system>
+</systemList>

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -1961,5 +1961,111 @@
   },
   "parserId": "164785656634747068",
   "version": 5
+  },
+  {
+    "parserType": "Glob",
+    "configTitle": "XBOX - Cxbx-Reloaded (.xbe)",
+    "steamCategory": "${XBOX}",
+    "executableArgs": "/load \"${filepath}\"",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/xbox/",
+    "steamDirectory": "/home/deck/.steam/steam",
+    "startInDirectory": "",
+    "imageProviders": ["SteamGridDB"],
+    "titleModifier": "${fuzzyTitle}",
+    "onlineImageQueries": "${${fuzzyTitle}}",
+    "imagePool": "${fuzzyTitle}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "disabled": false,
+    "advanced": false,
+    "executable": {
+      "path": "/run/media/mmcblk0p1/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "userAccounts": {
+      "specifiedAccounts": "",
+      "skipWithMissingDataDir": true,
+      "useCredentials": true
+    },
+    "parserInputs": {
+      "glob": "${title}/**/*.xbe"
+    },
+    "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+      "use": true,
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "parserId": "164950843165662319",
+    "version": 5
+  },
+  {
+    "parserType": "Glob",
+    "configTitle": "Cxbx-Reloaded Emulator (xbe)",
+    "steamCategory": "${Emulation}",
+    "executableArgs": "",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/xbox/",
+    "steamDirectory": "/home/deck/.steam/steam",
+    "startInDirectory": "",
+    "imageProviders": ["SteamGridDB"],
+    "titleModifier": "${fuzzyTitle}",
+    "onlineImageQueries": "${${fuzzyTitle}}",
+    "imagePool": "${fuzzyTitle}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "disabled": true,
+    "advanced": false,
+    "executable": {
+      "path": "/run/media/mmcblk0p1/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "userAccounts": {
+      "specifiedAccounts": "",
+      "skipWithMissingDataDir": true,
+      "useCredentials": true
+    },
+    "parserInputs": {
+      "glob": "${title}"
+    },
+    "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+      "use": true,
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "parserId": "164950877949290320",
+    "version": 5
   }
 ]

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ doYuzu=true
 doCitra=true
 doDuck=true
 doCemu=true
+doCxbxReloaded=true
 doRyujinx=true
 doPrimeHacks=true
 doPPSSPP=true
@@ -138,7 +139,8 @@ if [ -f "$SECONDTIME" ]; then
 						7 "Duckstation" \
 						8 "PPSSPP" \
 						9 "Yuzu" \
-						10 "Cemu") &>> /dev/null
+						10 "Cemu" \
+						11 "Cxbx-Reloaded") &>> /dev/null
 	clear
 	cat ~/dragoonDoriseTools/EmuDeck/logo.ans
 	echo -e "${BOLD}EmuDeck ${version}${NONE}"
@@ -174,6 +176,9 @@ if [ -f "$SECONDTIME" ]; then
 		fi
 		if [[ "$emusToReset" == *"Cemu"* ]]; then
 			doCemu=false
+		fi
+		if [[ "$emusToReset" == *"Cxbx-Reloaded"* ]]; then
+			doCxbxReloaded=false
 		fi
 		
 	else
@@ -270,6 +275,8 @@ echo -e "Installing Yuzu"
 flatpak install flathub org.yuzu_emu.yuzu -y &>> ~/emudeck/emudeck.log
 echo -e "Installing Flatseal (RPCS3 FIX)"
 flatpak install flathub com.github.tchx84.Flatseal -y &>> ~/emudeck/emudeck.log
+echo -e "Installing Bottles"
+flatpak install flathub com.usebottles.bottles -y &>> ~/emudeck/emudeck.log
 
 #Cemu
 echo -e "Installing Cemu"
@@ -287,6 +294,46 @@ else
 	mv $romsPath/wiiu/tmp/*/* $romsPath/wiiu &>> ~/emudeck/emudeck.log
 	rm -rf $romsPath/wiiu/tmp &>> ~/emudeck/emudeck.log
 	rm -f $romsPath/wiiu/cemu_1.26.2.zip &>> ~/emudeck/emudeck.log
+fi
+
+echo -e ""
+
+#Cxbx-Reloaded
+echo -e "Installing Cxbx-Reloaded"
+# Add flatpak permissions
+flatpak override --user \
+	--filesystem="$toolsPath/Cxbx-Reloaded" \
+	--filesystem="$romsPath/xbox" \
+	com.usebottles.bottles &>> ~/emudeck/emudeck.log
+
+cxbx_reloaded_version_file="$toolsPath/Cxbx-Reloaded/version"
+cxbx_reloaded_version_current=""
+cxbx_reloaded_resp="$(curl -sSL \
+	-H 'Accept: application/vnd.github.v3+json' \
+	'https://api.github.com/repos/Cxbx-Reloaded/Cxbx-Reloaded/releases?per_page=1' | \
+	jq -r '.[0].assets[0].browser_download_url,.[0].tag_name')"
+cxbx_reloaded_dl_url="$(echo "$cxbx_reloaded_resp" | head -n 1)"
+cxbx_reloaded_version="$(echo "$cxbx_reloaded_resp" | tail -n 1)"
+if [ -f "$cxbx_reloaded_version_file" ]; then
+	cxbx_reloaded_version_current="$(head -n 1 "$cxbx_reloaded_version_file")"
+fi
+if [ "$cxbx_reloaded_version" != "$cxbx_reloaded_version_current" ]; then
+	echo -e "Downloading newer Cxbx-Reloaded release $cxbx_reloaded_version"
+	curl -sSLo "$toolsPath/Cxbx-Reloaded.zip" "$cxbx_reloaded_dl_url" &>> ~/emudeck/emudeck.log
+	unzip -o "$toolsPath/Cxbx-Reloaded.zip" -d "$toolsPath/Cxbx-Reloaded" &>> ~/emudeck/emudeck.log
+	echo "$cxbx_reloaded_version" > "$cxbx_reloaded_version_file"
+	rm -f "$toolsPath/Cxbx-Reloaded.zip" &>> ~/emudeck/emudeck.log
+fi
+
+# Use a bottle because proton fails to run the emulator
+if ! flatpak run --command="bottles-cli" com.usebottles.bottles -j list bottles | \
+	jq -e '[.[].Name == "cxbx-reloaded"] | any' &>> /dev/null; then
+	echo -e "Setting up bottle for Cxbx-Reloaded, please be patient"
+	flatpak run --command="bottles-cli" com.usebottles.bottles new \
+		--bottle-name cxbx-reloaded \
+		--environment gaming &>> ~/emudeck/emudeck.log
+	flatpak run --command="bottles-cli" com.usebottles.bottles edit \
+		--bottle cxbx-reloaded --params sync:futex2 &>> ~/emudeck/emudeck.log
 fi
 
 echo -e ""
@@ -317,7 +364,7 @@ echo -e "${GREEN}OK!${NONE}"
 
 echo -ne "${BOLD}Configuring EmulationStation DE...${NONE}"
 mkdir -p ~/.emulationstation/
-cp ~/dragoonDoriseTools/EmuDeck/configs/emulationstation/es_settings.xml ~/.emulationstation/es_settings.xml
+rsync -r ~/dragoonDoriseTools/EmuDeck/configs/emulationstation/ ~/.emulationstation/
 sed -i "s/\/run\/media\/mmcblk0p1\/Emulation\/roms\//${romsPathSed}/g" ~/.emulationstation/es_settings.xml
 #sed -i "s/name=\"ROMDirectory\" value=\"/name=\"ROMDirectory\" value=\"${romsPathSed}/g" ~/.emulationstation/es_settings.xml
 echo -e "${GREEN}OK!${NONE}"
@@ -482,6 +529,10 @@ fi
 if [ $doCemu == true ]; then
 	echo "" &>> ~/emudeck/emudeck.log
 	rsync -avhp ~/dragoonDoriseTools/EmuDeck/configs/cemu/ ${romsPath}/wiiu &>> ~/emudeck/emudeck.log
+fi
+if [ $doCxbxReloaded == true ]; then
+	echo "" &>> ~/emudeck/emudeck.log
+	rsync -avhp ~/dragoonDoriseTools/EmuDeck/configs/Cxbx-Reloaded/ "$toolsPath/Cxbx-Reloaded/" &>> ~/emudeck/emudeck.log
 fi
 if [ $doRyujinx == true ]; then
 	echo "" &>> ~/emudeck/emudeck.log


### PR DESCRIPTION
~~More feature complete, easier to set up and efficient than xemu.~~
A feature rich, efficient and easy to set up original xbox emulator:
- https://github.com/Cxbx-Reloaded/Cxbx-Reloaded

* A Bottle is set up (com.usebottles.bottles) to run it because Proton is erroring out when launching a game
* Automatically downloads the latest release if there is one
* Integrates into EmulationStation
* Steam Deck input binding functional

Note: Cxbx-Reloaded has an exclusive fullscreen option but it does bad things (resetting the desktop res and the rotation) on the deck and is not needed for fullscreen when launched in Game Mode.

Useful Hotkeys:
- ESC/Alt+F4: Close emulation
- F5: Start emulating
- F6: Stop emulating
- F9: Toggle framerate unlock hack
- F10/ALT+ENTER: Toggle fake windowed fullscreen
- F11: Switch between normal, wireframe, point graphics

![20220409160027_1](https://user-images.githubusercontent.com/1030423/162577658-fe2e1538-aef7-4ba2-9661-5c391ffb923d.jpg)
*Jet Set Radio Future*