### PR TITLE
[cemu] Set up cemu inside a bottle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ EmuDeck has preloaded configurations for Steam Rom Manager for the following sys
 | Nintendo 64               | Mupen64plus FZ                       | .7z .bin .n64 .ndd u1 .v64 .z64 .zip                           |
 | Nintendo GameCube         | Dolphin Standalone                   | .ciso .dol .elf .gcm .gcz .iso .nkit .iso .rvz .wad .wia .wbfs |
 | Nintendo Wii              | Dolphin Standalone                   | .ciso .dol .elf .gcm .gcz .iso .nkit .iso .rvz .wad .wia .wbfs |
-| Nintendo Wii U            | Cemu ( Proton )                      | .rpx .wud .wux                                                 |
+| Nintendo Wii U            | Cemu                                 | .rpx .wud .wux                                                 |
 | Nintendo Switch           | Yuzu                                 | .kp .nca .nro .nso .nsp .xci                                   |
 | Super Nintendo            | Retroarch Snes9x Current core        | .7z .bs .fig .sfc .smc .swx .zip                               |
 | Super Nintendo Widescreen | Retroarch bsnes hd beta Current core | .7z .bs .fig .sfc .smc .swx .zip                               |

--- a/configs/cemu/cemu-wrapper
+++ b/configs/cemu/cemu-wrapper
@@ -1,0 +1,24 @@
+#!/bin/bash
+cemu_exe="$(realpath "$(dirname "$0")/Cemu.exe")"
+cemu_bottle='cemu'
+args=("$@")
+i=0
+for a in "${args[@]}"
+do
+    if [[ "${a}" == "-g" ]] && [[ $((i+1)) -lt ${#args[@]} ]]
+    then
+        na="${args[$((i+1))]}"
+        if ! [[ "$na" =~ ^[a-zA-Z]:\\ ]]
+        then
+            # we transform the unix path to the equivalent windows path
+            na="$(realpath "$na")"
+            na="Z:${na//\//\\}"
+            args[$((i+1))]="$na"
+        fi
+    fi
+    i=$((i+1))
+done
+exec flatpak run --command="bottles-cli" com.usebottles.bottles run \
+    -b "$cemu_bottle" \
+    -e "$cemu_exe" \
+    -a "${args[*]@Q}"

--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleList>
+    <emulator name="CEMU">
+        <!-- Nintendo Wii U emulator Cemu -->
+        <rule type="systempath">
+            <entry>cemu-wrapper</entry>
+        </rule>
+        <rule type="staticpath">
+            <entry>/home/deck/Emulation/tools/cemu/cemu-wrapper</entry>
+            <entry>/run/media/mmcblk0p1/Emulation/tools/cemu/cemu-wrapper</entry>
+            <entry>/var/lib/flatpak/exports/bin/cemu-wrapper</entry>
+            <entry>~/.local/share/flatpak/exports/bin/cemu-wrapper</entry>
+            <entry>~/Applications/cemu-wrapper</entry>
+            <entry>~/.local/bin/cemu-wrapper</entry>
+            <entry>~/bin/cemu-wrapper</entry>
+        </rule>
+    </emulator>
+</ruleList>

--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<systemList>
+    <system>
+        <name>wiiu</name>
+        <fullname>Nintendo Wii U</fullname>
+        <path>%ROMPATH%/wiiu</path>
+        <extension>.rpx .RPX .wud .WUD .wux .WUX</extension>
+        <command label="Cemu (Standalone)">%EMULATOR_CEMU% -f -g %ROM%</command>
+        <platform>wiiu</platform>
+        <theme>wiiu</theme>
+    </system>
+</systemList>

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -1170,9 +1170,9 @@
     "parserType": "Glob",
     "configTitle": "WiiU - Cemu (.rpx)",
     "steamCategory": "${WiiU}",
-    "executableArgs": "-f -g \"Z:${filepath}\"",
+    "executableArgs": "-f -g \"${filepath}\"",
     "executableModifier": "\"${exePath}\"",
-    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/wiiu/roms/",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/wiiu/",
     "steamDirectory": "/home/deck/.steam/steam",
     "startInDirectory": "",
     "imageProviders": ["SteamGridDB"],
@@ -1192,7 +1192,7 @@
     "disabled": false,
     "advanced": false,
     "executable": {
-      "path": "/run/media/mmcblk0p1/Emulation/roms/wiiu/Cemu.exe",
+      "path": "/run/media/mmcblk0p1/Emulation/tools/cemu/cemu-wrapper",
       "shortcutPassthrough": false,
       "appendArgsToExecutable": true
     },
@@ -1223,9 +1223,9 @@
     "parserType": "Glob",
     "configTitle": "WiiU - Cemu (.wud, .wux)",
     "steamCategory": "${WiiU}",
-    "executableArgs": "-f -g \"Z:${filepath}\"",
+    "executableArgs": "-f -g \"${filepath}\"",
     "executableModifier": "\"${exePath}\"",
-    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/wiiu/roms/",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/wiiu/",
     "steamDirectory": "/home/deck/.steam/steam",
     "startInDirectory": "",
     "imageProviders": ["SteamGridDB"],
@@ -1245,7 +1245,7 @@
     "disabled": false,
     "advanced": false,
     "executable": {
-      "path": "/run/media/mmcblk0p1/Emulation/roms/wiiu/Cemu.exe",
+      "path": "/run/media/mmcblk0p1/Emulation/tools/cemu/cemu-wrapper",
       "shortcutPassthrough": false,
       "appendArgsToExecutable": true
     },

--- a/roms/wiiu/roms/readme.txt
+++ b/roms/wiiu/roms/readme.txt
@@ -1,1 +1,0 @@
-place your roms here


### PR DESCRIPTION
* Cemu's wine prefix manageable using com.usebottles.bottles
* Automatically downloads the latest cemu version
* Integrates cemu into EmulationStation

So this is what I would personally prefer using for my cemu setup compared to #32 
~~It's more flexible and integrates into EmulationStation.~~
^Sorry, for the choice of words here that can come across a bit condescending. Being able to manage the cemu wine prefix from one central place with access to a userfriendly interface to tweak things further has its merits in my humble opinion that fit my use case.

Unclutters the wiiu rom folder and moves the cemu installation into the tools folder.

Brb Imma play some Wind Waker
![20220423160420_1](https://user-images.githubusercontent.com/1030423/164909463-37cfbf87-9a83-4737-b41f-1f1c888ee3db.jpg)
![20220423160515_1](https://user-images.githubusercontent.com/1030423/164909465-cda9bb5e-6926-48f8-b5e8-dd207b61a99f.jpg)