### PR TITLE
[cxbx-reloaded] Add support for the original xbox emulator Cxbx-Reloaded v2

### DIFF
--- a/configs/Cxbx-Reloaded/cxbx-reloaded-wrapper
+++ b/configs/Cxbx-Reloaded/cxbx-reloaded-wrapper
@@ -1,0 +1,24 @@
+#!/bin/bash
+cxbx_reloaded_exe="$(realpath "$(dirname "$0")/cxbx.exe")"
+cxbx_reloaded_bottle='cxbx-reloaded'
+args=("$@")
+i=0
+for a in "${args[@]}"
+do
+    if [[ "${a,,}" == "/load" ]] && [[ $((i+1)) -lt ${#args[@]} ]]
+    then
+        na="${args[$((i+1))]}"
+        if ! [[ "$na" =~ ^[a-zA-Z]:\\ ]]
+        then
+            # we transform the unix path to the equivalent windows path
+            na="$(realpath "$na")"
+            na="Z:${na//\//\\}"
+            args[$((i+1))]="$na"
+        fi
+    fi
+    i=$((i+1))
+done
+exec flatpak run --command="bottles-cli" com.usebottles.bottles run \
+    -b "$cxbx_reloaded_bottle" \
+    -e "$cxbx_reloaded_exe" \
+    -a "${args[*]@Q}"

--- a/configs/Cxbx-Reloaded/settings.ini
+++ b/configs/Cxbx-Reloaded/settings.ini
@@ -1,0 +1,133 @@
+[gui]
+CxbxDebugMode = 0x0
+CxbxDebugLogFile = 
+DataStorageToggle = 0x1
+DataCustomLocation = 
+RecentXbeFiles =
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+RecentXbeFiles = 
+IgnoreInvalidXbeSig = false
+IgnoreInvalidXbeSec = false
+
+
+[core]
+Revision = 9
+FlagsLLE = 0x0
+KrnlDebugMode = 0x0
+KrnlDebugLogFile = 
+AllowAdminPrivilege = false
+LogLevel = 1
+LoggedModules = 0x0
+LoggedModules = 0x0
+LoggedModules = 0x0
+LogPopupTestCase = true
+LoaderExecutable = true
+
+
+[video]
+VideoResolution = Automatic (Xbox Default)
+adapter = 0x0
+Direct3DDevice = 0x0
+VSync = false
+FullScreen = false
+MaintainAspect = true
+RenderResolution = 1
+
+
+[audio]
+adapter = 00000000 0000 0000 0000 000000000000
+PCM = true
+XADPCM = true
+UnknownCodec = true
+MuteOnUnfocus = true
+
+
+[network]
+adapter_name = 
+
+
+[input-general]
+MouseAxisRange = 10
+MouseWheelRange = 80
+IgnoreKbMoUnfocus = true
+
+
+[input-port-0]
+Type = 1
+DeviceName = XInput/0/Gamepad
+ProfileName = "Steam Deck"
+TopSlot = -1
+BottomSlot = -1
+
+
+[input-port-1]
+Type = -1
+DeviceName = 
+ProfileName = """
+TopSlot = -1
+BottomSlot = -1
+
+
+[input-port-2]
+Type = -1
+DeviceName = 
+ProfileName = """
+TopSlot = -1
+BottomSlot = -1
+
+
+[input-port-3]
+Type = -1
+DeviceName = 
+ProfileName = """
+TopSlot = -1
+BottomSlot = -1
+
+
+[overlay]
+FPS = false
+HLE/LLE Stats = false
+
+
+[hack]
+DisablePixelShaders = false
+UseAllCores = true
+SkipRdtscPatching = false
+
+
+[input-profile-0]
+Type = 1
+ProfileName = "Steam Deck"
+DeviceName = XInput/0/Gamepad
+D Pad Up = Pad N
+D Pad Down = Pad S
+D Pad Left = Pad W
+D Pad Right = Pad E
+Start = Start
+Back = Back
+L Thumb = Thumb L
+R Thumb = Thumb R
+A = Button A
+B = Button B
+X = Button X
+Y = Button Y
+Black = Shoulder R
+White = Shoulder L
+L Trigger = Trigger L
+R Trigger = Trigger R
+Left Axis X+ = Left X+
+Left Axis X- = Left X-
+Left Axis Y+ = Left Y+
+Left Axis Y- = Left Y-
+Right Axis X+ = Right X+
+Right Axis X- = Right X-
+Right Axis Y+ = Right Y+
+Right Axis Y- = Right Y-
+Motor = LeftRight

--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -265,4 +265,19 @@
             <entry>~/.local/share/flatpak/exports/bin/info.cemu.Cemu</entry>
         </rule>
     </emulator>
+    <emulator name="CXBX_RELOADED">
+        <!-- Microsoft Xbox emulator Cxbx-Reloaded -->
+        <rule type="systempath">
+            <entry>cxbx-reloaded-wrapper</entry>
+        </rule>
+        <rule type="staticpath">
+            <entry>/home/deck/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper</entry>
+            <entry>/run/media/mmcblk0p1/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper</entry>
+            <entry>/var/lib/flatpak/exports/bin/cxbx-reloaded-wrapper</entry>
+            <entry>~/.local/share/flatpak/exports/bin/cxbx-reloaded-wrapper</entry>
+            <entry>~/Applications/cxbx-reloaded-wrapper</entry>
+            <entry>~/.local/bin/cxbx-reloaded-wrapper</entry>
+            <entry>~/bin/cxbx-reloaded-wrapper</entry>
+        </rule>
+    </emulator>
 </ruleList>

--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -9,4 +9,14 @@
         <platform>wiiu</platform>
         <theme>wiiu</theme>
     </system>
+    <system>
+        <name>xbox</name>
+        <fullname>Microsoft Xbox</fullname>
+        <path>%ROMPATH%/xbox</path>
+        <extension>.xbe .XBE .iso .ISO</extension>
+        <command label="Cxbx-Reloaded (Standalone)">%EMULATOR_CXBX_RELOADED% /load %ROM%</command>
+        <command label="xemu (Standalone)">%EMULATOR_XEMU% -full-screen -dvd_path %ROM%</command>
+        <platform>xbox</platform>
+        <theme>xbox</theme>
+    </system>
 </systemList>

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2013,5 +2013,111 @@
     },
     "parserId": "164785656634747068",
     "version": 5
+  },
+  {
+    "parserType": "Glob",
+    "configTitle": "XBOX - Cxbx-Reloaded (.xbe)",
+    "steamCategory": "${XBOX}",
+    "executableArgs": "/load \"${filepath}\"",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/xbox/",
+    "steamDirectory": "/home/deck/.steam/steam",
+    "startInDirectory": "",
+    "imageProviders": ["SteamGridDB"],
+    "titleModifier": "${fuzzyTitle}",
+    "onlineImageQueries": "${${fuzzyTitle}}",
+    "imagePool": "${fuzzyTitle}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "disabled": false,
+    "advanced": false,
+    "executable": {
+      "path": "/run/media/mmcblk0p1/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "userAccounts": {
+      "specifiedAccounts": "",
+      "skipWithMissingDataDir": true,
+      "useCredentials": true
+    },
+    "parserInputs": {
+      "glob": "${title}/**/*.xbe"
+    },
+    "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+      "use": true,
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "parserId": "164950843165662319",
+    "version": 5
+  },
+  {
+    "parserType": "Glob",
+    "configTitle": "Cxbx-Reloaded Emulator (xbe)",
+    "steamCategory": "${Emulation}",
+    "executableArgs": "",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/xbox/",
+    "steamDirectory": "/home/deck/.steam/steam",
+    "startInDirectory": "",
+    "imageProviders": ["SteamGridDB"],
+    "titleModifier": "${fuzzyTitle}",
+    "onlineImageQueries": "${${fuzzyTitle}}",
+    "imagePool": "${fuzzyTitle}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "disabled": true,
+    "advanced": false,
+    "executable": {
+      "path": "/run/media/mmcblk0p1/Emulation/tools/Cxbx-Reloaded/cxbx-reloaded-wrapper",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "userAccounts": {
+      "specifiedAccounts": "",
+      "skipWithMissingDataDir": true,
+      "useCredentials": true
+    },
+    "parserInputs": {
+      "glob": "${title}"
+    },
+    "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+      "use": true,
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "parserId": "164950877949290320",
+    "version": 5
   }
 ]


### PR DESCRIPTION
A feature rich, efficient and easy to set up original xbox emulator:
- https://github.com/Cxbx-Reloaded/Cxbx-Reloaded

* A Bottle is set up (com.usebottles.bottles) to run it because Proton is erroring out when launching a game
* Automatically downloads the latest release if there is one
* Integrates into EmulationStation
* Steam Deck input binding functional

Note: Cxbx-Reloaded has an exclusive fullscreen option but it does bad things (resetting the desktop res and the rotation) on the deck and is not needed for fullscreen when launched in Game Mode.

Useful Hotkeys:
- ESC/Alt+F4: Close emulation
- F5: Start emulating
- F6: Stop emulating
- F9: Toggle framerate unlock hack
- F10/ALT+ENTER: Toggle fake windowed fullscreen
- F11: Switch between normal, wireframe, point graphics

![20220409160027_1](https://user-images.githubusercontent.com/1030423/162577658-fe2e1538-aef7-4ba2-9661-5c391ffb923d.jpg)
*Jet Set Radio Future*