### PR TITLE
Update the WiiU Cemu configuration to include the new .wua file format introduced in Cemu 1.27

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -1221,7 +1221,7 @@
   },
   {
     "parserType": "Glob",
-    "configTitle": "WiiU - Cemu (.wud, .wux)",
+    "configTitle": "WiiU - Cemu (.wud, .wux, .wua)",
     "steamCategory": "${WiiU}",
     "executableArgs": "-f -g \"Z:${filepath}\"",
     "executableModifier": "\"${exePath}\"",
@@ -1255,7 +1255,7 @@
       "useCredentials": true
     },
     "parserInputs": {
-      "glob": "${title}@(7z|7Z|.zip|.ZIP|wux|wud|wad|iso)"
+      "glob": "${title}@(7z|7Z|.zip|.ZIP|wux|wud|wua|wad|iso)"
     },
     "titleFromVariable": {
       "limitToGroups": "",


### PR DESCRIPTION
New .wua file format allows packing games and their updates and DLCs into a single archive file for cemu to read. This should be included in the config profile.