### PR TITLE
Checkout specific release tag from PowerTools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1460,7 +1460,8 @@ if [ $doInstallPowertools == true ]; then
 		sudo rm -rf ~/homebrew/plugins/PowerTools
 		sudo git clone https://github.com/NGnius/PowerTools.git ~/homebrew/plugins/PowerTools >> ~/emudeck/emudeck.log
 		sleep 1
-		cd ~/homebrew/plugins/PowerTools		
+		cd ~/homebrew/plugins/PowerTools
+		sudo git checkout tags/v0.3.0 >> ~/emudeck/emudeck.log
 		text="`printf "To finish the installation go into the Steam UI Settings\n\n
 		Under System -> System Settings toggle Enable Developer Mode\n\n
 		Scroll the sidebar all the way down and click on Developer\n\n

--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ cat ~/dragoonDoriseTools/EmuDeck/latest.md
 # Installation mode selection
 #
 
-text="`printf "<b>Hi!</b>\nDo you want to run EmuDeck on Easy or Expert mode?\n\n<b>Easy Mode</b> takes care of everything for you, it is an unattended installation.\n\n<b>Expert mode</b> gives you a bit more of control on how EmuDeck configures your system"`"
+text="`printf "<b>Hi!</b>\nDo you want to run EmuDeck on Easy or Expert mode?\n\n<b>Easy Mode</b> takes care of everything for you, it is an unattended installation.\n\n<b>Expert mode</b> gives you a bit more of control on how EmuDeck configures your system like giving you the option to install PowerTools or keep your custom configurations per Emulator"`"
 zenity --question \
 		 --title="EmuDeck" \
 		 --width=250 \


### PR DESCRIPTION
Pulling directly from the main branch is dangerous, since it's not guaranteed to be stable.
This checks out v0.3.0 (latest release at time of PR) instead.