### PR TITLE
rewrote chdman script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1427,6 +1427,11 @@ if [ $doInstallCHD == true ]; then
 	StartupNotify=false" > ~/Desktop/EmuDeckCHD.desktop
 	chmod +x ~/Desktop/EmuDeckCHD.desktop	
 	chmod +x $toolsPath/chdconv/chddesk.sh
+	chmod +x $toolsPath/chdconv/chdman5
+	#update the paths in the script
+	sed -i "s|/run/media/mmcblk0p1/Emulation/roms/|${romsPath}|g" $toolsPath/chdconv/chddesk.sh
+	sed -i "s|/run/media/mmcblk0p1/Emulation/tools/|${toolsPath}|g" $toolsPath/chdconv/chddesk.sh
+
 fi
 
 if [ $doInstallPowertools == true ]; then

--- a/tools/chdconv/chddeck.sh
+++ b/tools/chdconv/chddeck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-text="`printf "<b>Hi!</b>\nWelcome to EmuDeck's CHD conversion script!\n\nThis script will scan all your roms folders and convert all your .cue/.bin and .gdi files to the superior CHD format.\n\n<b>This action will delete the old files if the conversion to chd succeeds</b>"`"
+text="`printf "<b>Hi!</b>\nWelcome to EmuDeck's CHD conversion script!\n\nThis script will scan the roms folder you choose and convert all your .cue/.bin and .gdi files to the superior CHD format.\n\n<b>This action will delete the old files if the conversion to chd succeeds</b>"`"
 #Nova fix'
 zenity --question \
 		 --title="EmuDeck" \
@@ -10,38 +10,48 @@ zenity --question \
 		 --text="${text}" &>> /dev/null
 ans=$?
 if [ $ans -eq 0 ]; then
-	text="Do you have your files on your SD Card or on your Internal Storage?"
-	zenity --question \
-			 --title="EmuDeck" \
-			 --width=250 \
-			 --ok-label="SD Card" \
-			 --cancel-label="Internal Storage" \
-			 --text="${text}" &>> /dev/null
-	ans=$?
-	if [ $ans -eq 0 ]; then
-		echo "Storage: SD" &>> ~/emudeck/emudeck.log
-		destination="SD"
-		echo "" > ~/emudeck/.SD
-	else
-		echo "Storage: INTERAL" &>> ~/emudeck/emudeck.log
-		destination="INTERNAL"
-	fi
-	
-	if [ $destination == "SD" ]; then
-		romsPath="/run/media/mmcblk0p1/Emulation/roms"
-		chdPath="/run/media/mmcblk0p1/Emulation/tools/chdconv"
-	else
-		romsPath=~/Emulation/roms
-		chdPath=~/Emulation/tools/chdconv
-	fi
+	#paths update via sed in main script
+	romsPath="/run/media/external/mmcblk0p1/roms/"
+	chdPath="/run/media/external/mmcblk0p1/tools/chdconv/"
 
-	chmod +x ~"${chdPath}"/chdman5
+	#whitelist
+	declare -a folderWhiteList=("dreamcast" "psx" "segacd" "3d0" "saturn" "tg-cd" "pcenginecd" "pcfx" "amigacd32" "neogeocd" "megacd")
+	declare -a searchFolderList
+
 	export PATH="${chdPath}/:$PATH"
-	
-	find "$romsPath" -not -path "$romsPath/psp/*" -type f -name "*.cue" | while read f; do chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "${f%.*}.cue" && rm -rf "${f%.*}.bin"; done;
-	find "$romsPath" -not -path "$romsPath/psp/*" -type f -name "*.gdi" | while read f; do chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "${f%.*}.cue" && rm -rf "${f%.*}.bin"; done;
-	find "$romsPath" -not -path "$romsPath/psp/*" -type f -name "*.iso" | while read f; do chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "${f%.*}.cue" && rm -rf "${f%.*}.bin"; done;
-	
+
+	#find file types we support within whitelist of folders
+	for romfolder in ${folderWhiteList[@]}; do
+		echo "Checking $romsPath""$romfolder"
+		files=(`find "$romsPath""$romfolder" -type f -iname "*.gdi" -o -type f -iname "*.cue" -o -type f -iname "*.iso"`)
+		if [ ${#files[@]} -gt 0 ]; then 
+			echo "found in $romfolder"
+			searchFolderList+=("$romfolder")
+		fi
+	done
+	numFolders=${#searchFolderList[@]}
+	declare -i height=$numFolders*100
+	selectColumnStr="RomFolder " 
+	for (( i=1; i<=$numFolders; i++ )); do selectColumnStr+="$i ${searchFolderList[$i-1]} " ; done
+	text="`printf "What folders do you want to convert?"`"
+	folderstoconvert=$(zenity --list \
+				--title="EmuDeck" \
+				--height=$height \
+				--width=250 \
+				--ok-label="OK" \
+				--cancel-label="Exit" \
+				--text="${text}" \
+				--checklist \
+				--column="" \
+				--column=${selectColumnStr})
+	#folderstoconvert=(`echo $folderstoconvert | sed 's/|/ /g'`)
+	IFS="|"
+	IFS=', ' read -r -a romfolders <<< "$folderstoconvert"
+	for romfolder in ${romfolders[@]}; do
+		find "$romsPath$romfolder" -type f -iname "*.cue" | while read f; do chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "$f" && rm -rf "${f%.*}.bin" && rm -rf "${f%.*}.BIN"; done;
+		find "$romsPath$romfolder" -type f -iname "*.gdi" | while read f; do chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "$f"; done;
+		find "$romsPath$romfolder" -type f -iname "*.iso" | while read f; do chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "$f"; done;
+	done
 else
 	exit
 fi


### PR DESCRIPTION
Now when the script and bin are dumped in the tools path, they get set as executable at that point.
The paths inside the script are updated according to what the user chose at the start of the emudeck install.

when the script is run it will scan the applicable folders only (many can't use chd) via whitelist variable.
it will search for gdi, bin, iso files.
the user will be presented with a list of folders with files which can be converted.
the user can select any set of these folders for processing.