### PR TITLE
Fix PCSX2 Save/Load state mappings

### DIFF
--- a/configs/net.pcsx2.PCSX2/config/PCSX2/inis/PCSX2_keys.ini
+++ b/configs/net.pcsx2.PCSX2/config/PCSX2/inis/PCSX2_keys.ini
@@ -32,9 +32,9 @@
 # KP_DIVIDE WINDOWS_LEFT WINDOWS_RIGHT WINDOWS_MENU COMMAND
 
 # save state: freeze is save state, defrost is load state.
-States_FreezeCurrentSlot          = F1
-States_DefrostCurrentSlot         = F3
-States_DefrostCurrentSlotBackup   = Shift-F3
+States_FreezeCurrentSlot          = Shift-F1
+States_DefrostCurrentSlot         = Shift-F3
+States_DefrostCurrentSlotBackup   = Shift-F5
 States_CycleSlotForward           = F2
 States_CycleSlotBackward          = Shift-F2
 

--- a/configs/steam-input/pcsx2_controller_config.vdf
+++ b/configs/steam-input/pcsx2_controller_config.vdf
@@ -716,7 +716,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press K"
+							"binding"		"key_press F3"
 						}
 					}
 				}
@@ -739,7 +739,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press L"
+							"binding"		"key_press F1"
 						}
 					}
 				}


### PR DESCRIPTION
There seems to be a bug in PCSX2 with mappings involving letter keys, like the current Shift-L and Shift-K.

I have changed the save/load state hotkeys to use Shift-F1 and Shift-F3 and also make use of the intended actions "States_FreezeCurrentSlot" and "States_DefrostCurrentSlot".

I also updated the steam input mapping for PCSX2 to make use of these new hotkeys. I was able to test this on my steamdeck.