### PR TITLE
Trailing slashes in directories saved to variables are evil

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1031,8 +1031,8 @@ if [ $doUpdateRPCS3 == true ]; then
 	fi
 
 	rsync -avhp ~/dragoonDoriseTools/EmuDeck/configs/net.rpcs3.RPCS3/ ~/.var/app/net.rpcs3.RPCS3/ &>> ~/emudeck/emudeck.log
-	sed -i 's| $(EmulatorDir)dev_hdd0/| '$savesPath'/rpcs3/dev_hdd0/|g' /home/deck/.var/app/net.rpcs3.RPCS3/config/rpcs3/vfs.yml >> ~/emudeck/emudeck.log
-	mkdir -p $savesPath/rpcs3/dev_hdd0 >> ~/emudeck/emudeck.log
+	sed -i 's| $(EmulatorDir)dev_hdd0/| "$savesPath"rpcs3/dev_hdd0/|g' /home/deck/.var/app/net.rpcs3.RPCS3/config/rpcs3/vfs.yml >> ~/emudeck/emudeck.log
+	mkdir -p "$savesPath"rpcs3/dev_hdd0 >> ~/emudeck/emudeck.log
 fi
 if [ $doUpdateCitra == true ]; then
 	FOLDER=~/.var/app/org.citra_emu.citra/config_bak
@@ -1285,190 +1285,190 @@ fi
 #We move all the saved folders to the emulation path
 
 #RA
-if [ ! -d "$savesPath/retroarch/states" ]; then		
-	mkdir -p $savesPath/retroarch
+if [ ! -d "${savesPath}retroarch/states" ]; then		
+	mkdir -p "${savesPath}"retroarch
 	echo -e ""
 	echo -e "Linking RetroArch saved states to the Emulation/saves folder"			
 	echo -e ""	
 	mkdir -p ~/.var/app/org.libretro.RetroArch/config/retroarch/states 
-	ln -sn ~/.var/app/org.libretro.RetroArch/config/retroarch/states $savesPath/retroarch/states 
+	ln -sn ~/.var/app/org.libretro.RetroArch/config/retroarch/states "${savesPath}"retroarch/states 
 fi
-if [ ! -d "$savesPath/retroarch/saves" ]; then	
-	mkdir -p $savesPath/retroarch
+if [ ! -d "${savesPath}retroarch/saves" ]; then	
+	mkdir -p "${savesPath}"retroarch
 	echo -e ""
 	echo -e "Linking RetroArch saved games to the Emulation/saves folder"			
 	echo -e ""
 	mkdir -p ~/.var/app/org.libretro.RetroArch/config/retroarch/saves 
-	ln -sn ~/.var/app/org.libretro.RetroArch/config/retroarch/saves $savesPath/retroarch/saves 		
+	ln -sn ~/.var/app/org.libretro.RetroArch/config/retroarch/saves "${savesPath}"retroarch/saves 		
 fi
 
 #Dolphin
-if [ ! -d "$savesPath/dolphin/GC" ]; then	
-	mkdir -p $savesPath/dolphin	
+if [ ! -d "${savesPath}dolphin/GC" ]; then	
+	mkdir -p "${savesPath}"dolphin	
 	echo -e ""
 	echo -e "Linking Dolphin Gamecube saved games to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC && mv $savesPath/dolphin/GC ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC
+	unlink ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC && mv "${savesPath}"dolphin/GC ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC
 	mkdir -p ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC
-	ln -sn ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC $savesPath/dolphin/GC 
+	ln -sn ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC "${savesPath}"dolphin/GC 
 fi
-if [ ! -d "$savesPath/dolphin/Wii" ]; then	
-	mkdir -p $savesPath/dolphin	
+if [ ! -d "${savesPath}dolphin/Wii" ]; then	
+	mkdir -p "${savesPath}"dolphin	
 	echo -e ""
 	echo -e "Linking Dolphin Wii saved games to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii && mv $savesPath/dolphin/Wii ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii
+	unlink ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii && mv "${savesPath}"dolphin/Wii ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii
 	mkdir -p ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii	
-	ln -sn ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii $savesPath/dolphin/Wii 
+	ln -sn ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii "${savesPath}"dolphin/Wii 
 fi
-if [ ! -d "$savesPath/dolphin/states" ]; then	
-	mkdir -p $savesPath/dolphin	
+if [ ! -d "${savesPath}dolphin/states" ]; then	
+	mkdir -p "${savesPath}"dolphin	
 	echo -e ""
 	echo -e "Linking Dolphin States to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves && mv $savesPath/dolphin/states ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves
+	unlink ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves && mv "${savesPath}"dolphin/states ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves
 	mkdir -p ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves
-	ln -sn ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves $savesPath/dolphin/states
+	ln -sn ~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves "${savesPath}"dolphin/states
 fi
 
 #PrimeHack
-if [ ! -d "$savesPath/primehack/GC" ]; then	
-	mkdir -p $savesPath/primehack	
+if [ ! -d "${savesPath}primehack/GC" ]; then	
+	mkdir -p "${savesPath}"primehack	
 	echo -e ""
 	echo -e "Linking PrimeHack Gamecube saved games to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC && mv $savesPath/primehack/GC ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC	
+	unlink ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC && mv "${savesPath}"primehack/GC ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC	
 	mkdir -p ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC
-	ln -sn ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC $savesPath/primehack/GC
+	ln -sn ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/GC "${savesPath}"primehack/GC
 fi
-if [ ! -d "$savesPath/primehack/Wii" ]; then	
-	mkdir -p $savesPath/primehack	
+if [ ! -d "${savesPath}primehack/Wii" ]; then	
+	mkdir -p "${savesPath}"primehack	
 	echo -e ""
 	echo -e "Linking PrimeHack Wii saved games to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii && mv $savesPath/primehack/Wii ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii
+	unlink ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii && mv "${savesPath}"primehack/Wii ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii
 	mkdir -p ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii
-	ln -sn ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii $savesPath/primehack/Wii	
+	ln -sn ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii "${savesPath}"primehack/Wii	
 fi
-if [ ! -d "$savesPath/primehack/states" ]; then	
-	mkdir -p $savesPath/primehack	
+if [ ! -d "${savesPath}primehack/states" ]; then	
+	mkdir -p "${savesPath}"primehack	
 	echo -e ""
 	echo -e "Linking PrimeHack States to the Emulation/states folder"			
 	echo -e ""
-	unlink ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves && mv $savesPath/primehack/states ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves
+	unlink ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves && mv "${savesPath}"primehack/states ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves
 	mkdir -p ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves
-	ln -sn ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves $savesPath/primehack/states
+	ln -sn ~/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves "${savesPath}"primehack/states
 fi
 
 #Yuzu
-if [ ! -d "$savesPath/yuzu/saves" ]; then		
-	mkdir -p $savesPath/citra
+if [ ! -d "${savesPath}yuzu/saves" ]; then		
+	mkdir -p "${savesPath}"citra
 	echo -e ""
 	echo -e "Linking Citra Saves to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc && mv $savesPath/yuzu/saves ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc
+	unlink ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc && mv "${savesPath}"yuzu/saves ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc
 	mkdir -p ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc
-	ln -sn ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc $savesPath/yuzu/saves	
+	ln -sn ~/.var/app/org.yuzu_emu.yuzu/data/yuzu/sdmc "${savesPath}"yuzu/saves	
 fi
 
 #Duckstation
-if [ ! -d "$savesPath/duckstation/saves" ]; then		
-	mkdir -p $savesPath/duckstation
+if [ ! -d "${savesPath}duckstation/saves" ]; then		
+	mkdir -p "${savesPath}"duckstation
 	echo -e ""
 	echo -e "Linking Duckstation Saves to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards && mv $savesPath/duckstation/saves ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards
+	unlink ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards && mv "${savesPath}"duckstation/saves ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards
 	mkdir -p ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards
-	ln -sn ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards $savesPath/duckstation/saves	
+	ln -sn ~/.var/app/org.duckstation.DuckStation/data/duckstation/memcards "${savesPath}"duckstation/saves	
 fi
-if [ ! -d "$savesPath/duckstation/states" ]; then	
-	mkdir -p $savesPath/duckstation	
+if [ ! -d "${savesPath}duckstation/states" ]; then	
+	mkdir -p "${savesPath}"duckstation	
 	echo -e ""
 	echo -e "Linking Duckstation Saves to the Emulation/states folder"			
 	echo -e ""
-	unlink ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates && mv $savesPath/duckstation/states ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates
+	unlink ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates && mv "${savesPath}"duckstation/states ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates
 	mkdir -p ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates
-	ln -sn ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates $savesPath/duckstation/states
+	ln -sn ~/.var/app/org.duckstation.DuckStation/data/duckstation/savestates "${savesPath}"duckstation/states
 fi
 
 #Xemu
-if [ ! -d "$savesPath/xemu" ]; then		
-	mkdir -p "$savesPath/xemu"
+if [ ! -d "${savesPath}xemu" ]; then		
+	mkdir -p "${savesPath}xemu"
 	echo -e ""
 	echo -e "Moving Xemu HDD and EEPROM to the Emulation/saves folder"			
 	echo -e ""
-	mv /home/deck/.var/app/app.xemu.xemu/data/xemu/xemu/xbox_hdd.qcow2 $savesPath/xemu 
-	mv /home/deck/.var/app/app.xemu.xemu/data/xemu/xemu/eeprom.bin $savesPath/xemu 	
+	mv /home/deck/.var/app/app.xemu.xemu/data/xemu/xemu/xbox_hdd.qcow2 "${savesPath}"xemu 
+	mv /home/deck/.var/app/app.xemu.xemu/data/xemu/xemu/eeprom.bin "${savesPath}"xemu 	
 fi
 
 #PCSX2
-if [ ! -d "$savesPath/pcsx2/saves" ]; then		
-	mkdir -p $savesPath/pcsx2
+if [ ! -d "${savesPath}pcsx2/saves" ]; then		
+	mkdir -p "${savesPath}"pcsx2
 	echo -e ""
 	echo -e "Linking PCSX2 Saves to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards && mv $savesPath/pcsx2/saves ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards
+	unlink ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards && mv "${savesPath}"pcsx2/saves ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards
 	mkdir -p ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards
-	ln -sn ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards $savesPath/pcsx2/saves
+	ln -sn ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/memcards "${savesPath}"pcsx2/saves
 fi
-if [ ! -d "$savesPath/pcsx2/states" ]; then	
-	mkdir -p $savesPath/pcsx2	
+if [ ! -d "${savesPath}pcsx2/states" ]; then	
+	mkdir -p "${savesPath}"pcsx2	
 	echo -e ""
 	echo -e "Linking PCSX2 Saves to the Emulation/states folder"			
 	echo -e ""
-	unlink ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates && mv $savesPath/pcsx2/states ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates
+	unlink ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates && mv "${savesPath}"pcsx2/states ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates
 	mkdir -p ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates
-	ln -sn ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates $savesPath/pcsx2/states
+	ln -sn ~/.var/app/net.pcsx2.PCSX2/config/PCSX2/sstates "${savesPath}"pcsx2/states
 fi
 
 #RPCS3
-if [ ! -d "$savesPath/rpcs3/dev_hdd0" ]; then		
+if [ ! -d "${savesPath}rpcs3/dev_hdd0" ]; then		
 	echo -e ""
 	echo -e "Moving rpcs3 hdd0 to the Emulation/Saves folder"			
 	echo -e "Depending on how many pkgs you have installed, this may take a while."
-	mkdir -p "$savesPath/rpcs3" >> ~/emudeck/emudeck.log
-	mv ~/.var/app/net.rpcs3.RPCS3/config/rpcs3/dev_hdd0 "$savesPath"/rpcs3/ >> ~/emudeck/emudeck.log
+	mkdir -p "${savesPath}rpcs3" >> ~/emudeck/emudeck.log
+	mv ~/.var/app/net.rpcs3.RPCS3/config/rpcs3/dev_hdd0 "${savesPath}"rpcs3/ >> ~/emudeck/emudeck.log
 	#update config file for the new loc $(emulatorDir) is in the file. made this annoying.
-	sed -i "'s|$(EmulatorDir)dev_hdd0/|'$savesPath'/rpcs3/dev_hdd0/|g'" /home/deck/.var/app/net.rpcs3.RPCS3/config/rpcs3/vfs.yml >> ~/emudeck/emudeck.log
+	sed -i "'s|$(EmulatorDir)dev_hdd0/|'${savesPath}'rpcs3/dev_hdd0/|g'" /home/deck/.var/app/net.rpcs3.RPCS3/config/rpcs3/vfs.yml >> ~/emudeck/emudeck.log
 fi
 
 #Citra
-if [ ! -d "$savesPath/citra/saves" ]; then		
-	mkdir -p $savesPath/citra
+if [ ! -d "${savesPath}citra/saves" ]; then		
+	mkdir -p "${savesPath}"citra
 	echo -e ""
 	echo -e "Linking Citra Saves to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc && mv $savesPath/citra/saves ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc
+	unlink ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc && mv "${savesPath}"citra/saves ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc
 	mkdir -p ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc
-	ln -sn ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc $savesPath/citra/saves
+	ln -sn ~/.var/app/org.citra_emu.citra/data/citra-emu/sdmc "${savesPath}"citra/saves
 fi
-if [ ! -d "$savesPath/citra/states" ]; then	
-	mkdir -p $savesPath/citra	
+if [ ! -d "${savesPath}citra/states" ]; then	
+	mkdir -p "${savesPath}"citra	
 	echo -e ""
 	echo -e "Linking Citra Saves to the Emulation/states folder"			
 	echo -e ""
-	unlink ~/.var/app/org.citra_emu.citra/data/citra-emu/states && mv $savesPath/citra/states ~/.var/app/org.citra_emu.citra/data/citra-emu/states
+	unlink ~/.var/app/org.citra_emu.citra/data/citra-emu/states && mv "${savesPath}"citra/states ~/.var/app/org.citra_emu.citra/data/citra-emu/states
 	mkdir -p ~/.var/app/org.citra_emu.citra/data/citra-emu/states
-	ln -sn ~/.var/app/org.citra_emu.citra/data/citra-emu/states $savesPath/citra/states
+	ln -sn ~/.var/app/org.citra_emu.citra/data/citra-emu/states "${savesPath}"citra/states
 fi
 #PPSSPP
-if [ ! -d "$savesPath/ppsspp/saves" ]; then		
-	mkdir -p $savesPath/ppsspp
+if [ ! -d "${savesPath}ppsspp/saves" ]; then		
+	mkdir -p "${savesPath}"ppsspp
 	echo -e ""
 	echo -e "Linking PPSSPP Saves to the Emulation/saves folder"			
 	echo -e ""
-	unlink ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA && mv $savesPath/ppsspp/saves ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA
+	unlink ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA && mv "${savesPath}"ppsspp/saves ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA
 	mkdir -p ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA
-	ln -sn ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA $savesPath/ppsspp/saves
+	ln -sn ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA "${savesPath}"ppsspp/saves
 fi
-if [ ! -d "$savesPath/ppsspp/states" ]; then	
-	mkdir -p $savesPath/ppsspp	
+if [ ! -d "${savesPath}ppsspp/states" ]; then	
+	mkdir -p "${savesPath}"ppsspp	
 	echo -e ""
 	echo -e "Linking PPSSPP Saves to the Emulation/states folder"			
 	echo -e ""
-	unlink ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE && mv $savesPath/ppsspp/states ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE
+	unlink ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE && mv "${savesPath}"ppsspp/states ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE
 	mkdir -p ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE
-	ln -sn ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE $savesPath/ppsspp/states	
+	ln -sn ~/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE "${savesPath}"ppsspp/states	
 fi
 
 #RetroAchievments


### PR DESCRIPTION
Trailing slashes causing trouble identifying correct directories:

"Cannot stat directory: /run/media/mmcblk0p1/Emulation/saves//yuzu/, no such directory'