### PR TITLE
Fix ${romsPath} variable expansion in sed command for cemu.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -830,7 +830,7 @@ if [ $doInstallCemu == "true" ]; then
 
 	if ! [ -f "${toolsPath}"launchers/cemu.sh ]; then
 		cp ~/dragoonDoriseTools/EmuDeck/tools/launchers/cemu.sh "${toolsPath}"launchers/cemu.sh
-		sed -i 's|/run/media/mmcblk0p1/Emulation/roms/wiiu|${romsPath}wiiu|' "${toolsPath}"launchers/cemu.sh
+		sed -i "s|/run/media/mmcblk0p1/Emulation/roms/wiiu|${romsPath}wiiu|" "${toolsPath}"launchers/cemu.sh
 		chmod +x ${toolsPath}/launchers/cemu.sh
 	fi
 	#Commented until we get CEMU flatpak working


### PR DESCRIPTION
There is currently a bug with the creation of `cemu.sh` launcher script. This bug only occurs if you select to install EmuDeck to work with internal storage, if you choose to setup EmuDeck to use an SD card there are no problems. 

This bug is caused because the `sed` command does not correctly expand `${romsPath}` variable.  The resulting `cemu.sh` file ultimately has a malformed `APPPATH` variable, which prevents Cemu from starting correctly.  Here is a snippet from the current cemu.sh that gets created if you install to internal storage.

```
## Config
# App Path
APPPATH="${romsPath}wiiu"
```

The bug is caused because single quotes in a `sed` command do not perform variable expansion.  The fix is to simply replace the single quotes with the double quotes.

It's worth noting that there are other `sed` substitutions throughout the install.sh file that _are_ working correctly.  For example, here are some examples for the Steam ROM Manager configuration:

```
#Steam RomManager Config

if [ $doUpdateSRM == true ]; then
	echo -ne "${BOLD}Configuring Steam Rom Manager...${NONE}"
	mkdir -p ~/.config/steam-rom-manager/userData/
	cp ~/dragoonDoriseTools/EmuDeck/configs/steam-rom-manager/userData/userConfigurations.json ~/.config/steam-rom-manager/userData/userConfigurations.json
	sleep 3
	sed -i "s|/run/media/mmcblk0p1/Emulation/roms/|${romsPath}|g" ~/.config/steam-rom-manager/userData/userConfigurations.json
	sed -i "s|/run/media/mmcblk0p1/Emulation/tools/|${toolsPath}|g" ~/.config/steam-rom-manager/userData/userConfigurations.json
	echo -e "${GREEN}OK!${NONE}"
fi
```
So this appears to be an exception.

I hope this helps!