### PR TITLE
Readme Fix: Change Name mupen64plus FZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ EmuDeck has preloaded configurations for Steam Rom Manager for the following sys
 | Nintendo DS               | Retroarch melonDS core               | .7z .nds .zip                                                        |
 | Nintendo 3DS              | Citra                                | .3ds .3dsx .app .axf .cii .cxi .elf .cia                             |
 | Nintendo NES              | Retroarch Nestopia core              | .7z .nes .fds .unf .unif .zip                                        |
-| Nintendo 64               | Mupen64plus-Next                       | .7z .bin .n64 .ndd u1 .v64 .z64 .zip                                 |
+| Nintendo 64               | Retroarch Mupen64plus-Next                       | .7z .bin .n64 .ndd u1 .v64 .z64 .zip                                 |
 | Nintendo GameCube         | Dolphin Standalone                   | .ciso .dol .elf .gcm .gcz .iso .nkit .iso .rvz .wad .wia .wbfs       |
 | Nintendo Wii              | Dolphin Standalone                   | .ciso .dol .elf .gcm .gcz .iso .json .nkit .iso .rvz .wad .wia .wbfs |
 | Nintendo Wii U            | Cemu                                 | .rpx .wud .wux .elf .iso .wad                                        |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ EmuDeck has preloaded configurations for Steam Rom Manager for the following sys
 | Nintendo DS               | Retroarch melonDS core               | .7z .nds .zip                                                        |
 | Nintendo 3DS              | Citra                                | .3ds .3dsx .app .axf .cii .cxi .elf .cia                             |
 | Nintendo NES              | Retroarch Nestopia core              | .7z .nes .fds .unf .unif .zip                                        |
-| Nintendo 64               | Mupen64plus FZ                       | .7z .bin .n64 .ndd u1 .v64 .z64 .zip                                 |
+| Nintendo 64               | Mupen64plus-Next                       | .7z .bin .n64 .ndd u1 .v64 .z64 .zip                                 |
 | Nintendo GameCube         | Dolphin Standalone                   | .ciso .dol .elf .gcm .gcz .iso .nkit .iso .rvz .wad .wia .wbfs       |
 | Nintendo Wii              | Dolphin Standalone                   | .ciso .dol .elf .gcm .gcz .iso .json .nkit .iso .rvz .wad .wia .wbfs |
 | Nintendo Wii U            | Cemu                                 | .rpx .wud .wux .elf .iso .wad                                        |

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2444,7 +2444,7 @@
     "parserType": "Glob",
     "configTitle": "Sony PlayStation 3 - RPCS3(Flatpak) (Installed PKG)",
     "steamCategory": "${PS3}",
-    "steamDirectory": "${steamdirglobal}",
+    "steamDirectory": "/home/deck/.steam/steam",
     "romDirectory": "/run/media/mmcblk0p1/Emulation/saves/rpcs3/dev_hdd0/game",
     "executableArgs": "run net.rpcs3.RPCS3 --no-gui \"${filePath}\"",
     "executableModifier": "\"${exePath}\"",

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -850,59 +850,6 @@
   },
   {
     "parserType": "Glob",
-    "configTitle": "Microsoft Xbox 360 - Xenia",
-    "steamCategory": "${Xbox 360}",
-    "executableArgs": "-f -g \"Z:${filepath}\"",
-    "executableModifier": "\"${exePath}\"",
-    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/xbox360/roms/",
-    "steamDirectory": "/home/deck/.steam/steam",
-    "startInDirectory": "",
-    "imageProviders": ["SteamGridDB"],
-    "titleModifier": "${fuzzyTitle}",
-    "onlineImageQueries": "${${fuzzyTitle}}",
-    "imagePool": "${fuzzyTitle}",
-    "defaultImage": "",
-    "defaultTallImage": "",
-    "defaultHeroImage": "",
-    "defaultLogoImage": "",
-    "defaultIcon": "",
-    "localImages": "",
-    "localTallImages": "",
-    "localHeroImages": "",
-    "localLogoImages": "",
-    "localIcons": "",
-    "disabled": false,
-    "advanced": false,
-    "executable": {
-      "path": "/run/media/mmcblk0p1/Emulation/roms/xbox360/xenia.exe",
-      "shortcutPassthrough": false,
-      "appendArgsToExecutable": true
-    },
-    "userAccounts": {
-      "specifiedAccounts": "",
-      "skipWithMissingDataDir": true,
-      "useCredentials": true
-    },
-    "parserInputs": {
-      "glob": "${title}@(.iso|.ISO|.xex|.XEX)"
-    },
-    "titleFromVariable": {
-      "limitToGroups": "",
-      "caseInsensitiveVariables": false,
-      "skipFileIfVariableWasNotFound": false,
-      "tryToMatchTitle": false
-    },
-    "fuzzyMatch": {
-      "use": true,
-      "replaceDiacritics": true,
-      "removeCharacters": true,
-      "removeBrackets": true
-    },
-    "parserId": "135113607715086732",
-    "version": 5
-  },
-  {
-    "parserType": "Glob",
     "configTitle": "Nintendo 3DS - Citra",
     "steamCategory": "${Nintendo 3DS}",
     "executableModifier": "\"${exePath}\"",

--- a/install.sh
+++ b/install.sh
@@ -1054,7 +1054,7 @@ if [ $doUpdateRPCS3 == true ]; then
 
 	rsync -avhp ~/dragoonDoriseTools/EmuDeck/configs/net.rpcs3.RPCS3/ ~/.var/app/net.rpcs3.RPCS3/ &>> ~/emudeck/emudeck.log
 	sed -i 's| $(EmulatorDir)dev_hdd0/| '$savesPath'/rpcs3/dev_hdd0/|g' /home/deck/.var/app/net.rpcs3.RPCS3/config/rpcs3/vfs.yml >> ~/emudeck/emudeck.log
-	mkdir -p $savesPath/rpcs3/dev_hdd0 >> ~/emudeck/emudeck.log
+	mkdir -p $savesPath/rpcs3/ >> ~/emudeck/emudeck.log
 fi
 if [ $doUpdateCitra == true ]; then
 	FOLDER=~/.var/app/org.citra_emu.citra/config_bak
@@ -1434,7 +1434,7 @@ if [ ! -d "$savesPath/pcsx2/states" ]; then
 fi
 
 #RPCS3
-if [ ! -d "$savesPath/rpcs3/dev_hdd0" ]; then		
+if [ ! -d "$savesPath/rpcs3/dev_hdd0/savedata" ]; then		
 	echo -e ""
 	echo -e "Moving rpcs3 hdd0 to the Emulation/Saves folder"			
 	echo -e "Depending on how many pkgs you have installed, this may take a while."

--- a/install.sh
+++ b/install.sh
@@ -1442,7 +1442,7 @@ if [ ! -d "$savesPath/rpcs3/dev_hdd0" ]; then
 		echo -e "If you don't have enough available space in your SD Card this will fail, clean up your SD Card and run EmuDeck Again."
 	fi
 	mkdir -p "$savesPath/rpcs3" >> ~/emudeck/emudeck.log
-	cp -r ~/.var/app/net.rpcs3.RPCS3/config/rpcs3/dev_hdd0 "$savesPath"/rpcs3/ && rm -rf ~/.var/app/net.rpcs3.RPCS3/config/rpcs3/dev_hdd0 >> ~/emudeck/emudeck.log
+	rsync -r ~/.var/app/net.rpcs3.RPCS3/config/rpcs3/dev_hdd0 "$savesPath"/rpcs3/ && rm -rf ~/.var/app/net.rpcs3.RPCS3/config/rpcs3/dev_hdd0 >> ~/emudeck/emudeck.log
 	#update config file for the new loc $(emulatorDir) is in the file. made this annoying.
 	sed -i "'s|$(EmulatorDir)dev_hdd0/|'$savesPath'/rpcs3/dev_hdd0/|g'" /home/deck/.var/app/net.rpcs3.RPCS3/config/rpcs3/vfs.yml >> ~/emudeck/emudeck.log
 fi


### PR DESCRIPTION
This change is to fix a typo on what type of Mupen64plus because the FZ variant of mupen64plus is a android edition of the program which this isn’t installing. Don’t want to add any confusion if people take it literally. Especially since there is many variants of Mupen64plus like for example Mupen64plus-ae or mupen64plus-core.