### PR TITLE
Update PowerTools to v0.4.1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1632,7 +1632,7 @@ if [ $doInstallPowertools == true ]; then
 		sudo git clone https://github.com/NGnius/PowerTools.git ~/homebrew/plugins/PowerTools >> ~/emudeck/emudeck.log
 		sleep 1
 		cd ~/homebrew/plugins/PowerTools
-		sudo git checkout tags/v0.4.0 >> ~/emudeck/emudeck.log
+		sudo git checkout tags/v0.4.1 >> ~/emudeck/emudeck.log
 		text="$(printf "To finish the installation go into the Steam UI Settings\n\n
 		Under System -> System Settings toggle Enable Developer Mode\n\n
 		Scroll the sidebar all the way down and click on Developer\n\n


### PR DESCRIPTION
This PowerTools update fixes the display breakage from the latest SteamOS update

https://github.com/NGnius/PowerTools/releases/tag/v0.4.1