### PR TITLE
Add support for holoISO

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -733,6 +733,7 @@ if [[ ! "$(cat /sys/devices/virtual/dmi/id/product_name)" =~ Jupiter ]]; then
 	wheel=$(awk '/'${USER}'/ {if ($1 ~ /wheel/) print}' /etc/group)
 	if [[ ! "${wheel}" =~ ${USER} ]]; then
 		sudo usermod -a -G wheel ${USER} &>> ~/emudeck/emudeck.log
+		newgrp wheel
 	fi
 
 	#Ensure the Desktop directory isn't owned by root

--- a/install.sh
+++ b/install.sh
@@ -722,8 +722,7 @@ if [ $doInstallSRM == true ]; then
 fi
 
 #We only want to execute on non-valve hardware.
-if [[ ! "$(cat /sys/devices/virtual/dmi/id/product_name)" =~ Jupiter ]]
-then
+if [[ ! "$(cat /sys/devices/virtual/dmi/id/product_name)" =~ Jupiter ]]; then
 	#Ensure the dependencies are installed before proceeding.
 	for package in packagekit-qt5 flatpak rsync unzip
 	do
@@ -732,14 +731,12 @@ then
 
 	#The user must be in the wheel group to install flatpaks successfully.
 	wheel=$(awk '/'${USER}'/ {if ($1 ~ /wheel/) print}' /etc/group)
-	if [[ ! "${wheel}" =~ ${USER} ]]
-	then
+	if [[ ! "${wheel}" =~ ${USER} ]]; then
 		sudo usermod -a -G wheel ${USER} &>> ~/emudeck/emudeck.log
 	fi
 
 	#Ensure the Desktop directory isn't owned by root
-	if [[ "$(stat -c %U ${HOME}/Desktop)" =~ root ]]
-	then
+	if [[ "$(stat -c %U ${HOME}/Desktop)" =~ root ]]; then
 		sudo chown -R ${USER}:${USER} ~/Desktop &>> ~/emudeck/emudeck.log
 	fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -720,7 +720,25 @@ if [ $doInstallSRM == true ]; then
 	#Nova fix'
 	chmod +x ~/Desktop/Steam-ROM-Manager.AppImage
 fi
-	
+
+#Ensure the dependencies are installed before proceeding.
+for package in packagekit-qt5 flatpak rsync unzip
+do
+  pacman -Q ${package} &>> ~/emudeck/emudeck.log || sudo pacman -Sy --noconfirm ${package} &>> ~/emudeck/emudeck.log
+done
+
+#The user must be in the wheel group to install flatpaks successfully.
+wheel=$(awk '/'${USER}'/ {if ($1 ~ /wheel/) print}' /etc/group)
+if [[ ! "${wheel}" =~ ${USER} ]]
+then
+  sudo usermod -a -G wheel ${USER} &>> ~/emudeck/emudeck.log
+fi
+
+#Ensure the Desktop directory isn't owned by root
+if [[ "$(stat -c %U ${HOME}/Desktop)" =~ root ]]
+then
+  sudo chown -R ${USER}:${USER} ~/Desktop &>> ~/emudeck/emudeck.log
+fi
 
 #Emulators Installation
 if [ $doInstallPCSX2 == "true" ]; then

--- a/install.sh
+++ b/install.sh
@@ -742,7 +742,6 @@ then
 	then
 		sudo chown -R ${USER}:${USER} ~/Desktop &>> ~/emudeck/emudeck.log
 	fi
-
 fi
 
 #Emulators Installation

--- a/install.sh
+++ b/install.sh
@@ -721,23 +721,28 @@ if [ $doInstallSRM == true ]; then
 	chmod +x ~/Desktop/Steam-ROM-Manager.AppImage
 fi
 
-#Ensure the dependencies are installed before proceeding.
-for package in packagekit-qt5 flatpak rsync unzip
-do
-  pacman -Q ${package} &>> ~/emudeck/emudeck.log || sudo pacman -Sy --noconfirm ${package} &>> ~/emudeck/emudeck.log
-done
-
-#The user must be in the wheel group to install flatpaks successfully.
-wheel=$(awk '/'${USER}'/ {if ($1 ~ /wheel/) print}' /etc/group)
-if [[ ! "${wheel}" =~ ${USER} ]]
+#We only want to execute on non-valve hardware.
+if [[ ! "$(cat /sys/devices/virtual/dmi/id/product_name)" =~ Jupiter ]]
 then
-  sudo usermod -a -G wheel ${USER} &>> ~/emudeck/emudeck.log
-fi
+	#Ensure the dependencies are installed before proceeding.
+	for package in packagekit-qt5 flatpak rsync unzip
+	do
+		pacman -Q ${package} &>> ~/emudeck/emudeck.log || sudo pacman -Sy --noconfirm ${package} &>> ~/emudeck/emudeck.log
+	done
 
-#Ensure the Desktop directory isn't owned by root
-if [[ "$(stat -c %U ${HOME}/Desktop)" =~ root ]]
-then
-  sudo chown -R ${USER}:${USER} ~/Desktop &>> ~/emudeck/emudeck.log
+	#The user must be in the wheel group to install flatpaks successfully.
+	wheel=$(awk '/'${USER}'/ {if ($1 ~ /wheel/) print}' /etc/group)
+	if [[ ! "${wheel}" =~ ${USER} ]]
+	then
+		sudo usermod -a -G wheel ${USER} &>> ~/emudeck/emudeck.log
+	fi
+
+	#Ensure the Desktop directory isn't owned by root
+	if [[ "$(stat -c %U ${HOME}/Desktop)" =~ root ]]
+	then
+		sudo chown -R ${USER}:${USER} ~/Desktop &>> ~/emudeck/emudeck.log
+	fi
+
 fi
 
 #Emulators Installation


### PR DESCRIPTION
This PR adds a few tests for non-valve devices running holoISO that correct missing dependencies so the emudeck installation completes successfully.

1. Verify that we're not executing on a Steam Deck.
2. Ensure dependent softwares are installed.
3. Make sure flatpak can install to the system without root.
4. Ensure that the Desktop directory is not owned by root.