### PR TITLE
Fix Sega Genesis missing extension and adds Commodore 64

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -744,6 +744,71 @@
   },
   {
     "parserType": "Glob",
+    "configTitle": "Commodore 64 - Retroarch",
+    "steamCategory": "${Commodore 64}",
+    "steamDirectory": "/home/deck/.steam/steam",
+    "romDirectory": "/home/deck/Emulation/roms/c64",
+    "executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_x64_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+    "executableModifier": "\"${exePath}\"",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "imageProviders": [
+        "SteamGridDB"
+    ],
+    "onlineImageQueries": "${${fuzzyTitle}}",
+    "imagePool": "${fuzzyTitle}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "userAccounts": {
+        "specifiedAccounts": "",
+        "skipWithMissingDataDir": true,
+        "useCredentials": true
+    },
+    "executable": {
+        "path": "/usr/bin/flatpak",
+        "shortcutPassthrough": false,
+        "appendArgsToExecutable": true
+    },
+    "parserInputs": {
+        "glob": "${title}@(.d64|.D64|.d71|.D71|.d80|.D80|.d81|.D81|.d82|.D82|.g64|.G64|.g41|.G41|.x64|.X64|.t64|.T64|.tap|.TAP|.prg|.PRG|.p00|.P00|.crt|.CRT|.bin|.BIN|.d6z|.D6Z|.d7z|.D7Z|.d8z|.D8Z|.g6z|.G6Z|.g4z|.G4Z|.x6z|.X6Z|.cmd|.CMD|.m3u|.M3U|.vsf|.VSF|.nib|.NIB|.nbz|.NBZ|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+        "limitToGroups": "",
+        "caseInsensitiveVariables": false,
+        "skipFileIfVariableWasNotFound": false,
+        "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+        "replaceDiacritics": true,
+        "removeCharacters": true,
+        "removeBrackets": true
+    },
+    "imageProviderAPIs": {
+        "SteamGridDB": {
+            "nsfw": false,
+            "humor": false,
+            "styles": [],
+            "stylesHero": [],
+            "stylesLogo": [],
+            "stylesIcon": [],
+            "imageMotionTypes": [
+                "static"
+            ]
+        }
+    },
+    "parserId": "164785598905497512",
+    "version": 10
+  },
+  {
+    "parserType": "Glob",
     "configTitle": "DOS - Retroarch(Flatpak) - DOSBox Pure",
     "steamCategory": "${DOS}",
     "executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}dosbox_pure_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\" -conf \"${filePath}${/}${title}.conf\"",
@@ -1944,7 +2009,7 @@
       "useCredentials": true
     },
     "parserInputs": {
-      "glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
+      "glob": "${title}@(.7z|.7Z|.bin|.BIN|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
     },
     "titleFromVariable": {
       "limitToGroups": "",
@@ -1997,7 +2062,7 @@
       "useCredentials": true
     },
     "parserInputs": {
-      "glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
+      "glob": "${title}@(.7z|.7Z|.bin|.BIN|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
     },
     "titleFromVariable": {
       "limitToGroups": "",

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -747,7 +747,7 @@
     "configTitle": "Commodore 64 - Retroarch",
     "steamCategory": "${Commodore 64}",
     "steamDirectory": "/home/deck/.steam/steam",
-    "romDirectory": "/home/deck/Emulation/roms/c64",
+    "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/c64",
     "executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_x64_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
     "executableModifier": "\"${exePath}\"",
     "startInDirectory": "",


### PR DESCRIPTION
This PR adds the .bin extension for Sega Genesis, and also adds a parser for Commodore 64.