### PR TITLE
Adds citra touchpad clicking

### DIFF
--- a/configs/steam-input/citra_controller_config.vdf
+++ b/configs/steam-input/citra_controller_config.vdf
@@ -590,7 +590,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT"
+							"binding"		"mouse_button LEFT"
 						}
 					}
 				}


### PR DESCRIPTION
In Citra the right trackpad click action was set to Right Stick Click, and I thought Left Mouse Click would feel more natural for the trackpad. Found the new binding `mouse_button LEFT` by exporting my edited config and checking the diff.