### PR TITLE
Shift+M doesn't work for TurboToggle

### DIFF
--- a/configs/net.pcsx2.PCSX2/config/PCSX2/inis/PCSX2_keys.ini
+++ b/configs/net.pcsx2.PCSX2/config/PCSX2/inis/PCSX2_keys.ini
@@ -39,7 +39,7 @@ States_CycleSlotForward           = F2
 States_CycleSlotBackward          = Shift-F2
 
 Frameskip_Toggle                  = Shift-F4
-Framelimiter_TurboToggle          = Shift-M
+Framelimiter_TurboToggle          = TAB
 Framelimiter_SlomoToggle          = Shift-TAB
 Framelimiter_MasterToggle         = F4
 


### PR DESCRIPTION
Default of TAB for PCSX2's TurboToggle works within the Steam Deck - For some reason Shift-M, even when mapped to USB Keyboard, didn't enable it.