### PR TITLE
Adjust default config to support FastForward

### DIFF
--- a/configs/steam-input/pcsx2_controller_config.vdf
+++ b/configs/steam-input/pcsx2_controller_config.vdf
@@ -370,7 +370,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press M"
+							"binding"		"key_press TAB"
 						}
 						"settings"
 						{


### PR DESCRIPTION
Default Key of Shift+M Ends up not functioning for FFWD on PCSX2 - Set it as TAB in PR #219 