### PR TITLE
Update Hotkeys to support FFWD

### DIFF
--- a/configs/steam-input/pcsx2_controller_config.vdf
+++ b/configs/steam-input/pcsx2_controller_config.vdf
@@ -803,7 +803,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press S"
+							"binding"		"key_press TAB"
 						}
 					}
 				}


### PR DESCRIPTION
Original Implementation didn't support Shift+M as fast forward (even with a keyboard). Updated it to TAB in #219 and adjusted Deck Config to make Back right upper TAB.