### PR TITLE
Fix Turbo Mode for PCSX2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We try to use the same hotkeys for every emulator but some of them have their ow
 | Menu            | L3 + R3        | -              | -        | -              | -              | -            | -            |
 | Exit            | Select + Start | Select + Start | R5       | Select + Start | Select + Start | STEAM Button | STEAM Button |
 | Pause/Unpause Emulation | Select + A     | Select + A     | -        | -              | Select + A     |              | -            |
-| Fast Forward    | Select + R2    | Select         | -        | -              | Select + R2    | Select + R2  | -            |
+| Fast Forward    | Select + R2    | Select         | -        | -              | Select + R2    | Select + R4  | -            |
 | Load State      | Select + L1    | Select + L1    | -        | -              | -              | Select + L1  | -            |
 | Save State      | Select + R1    | Select + R1    | -        | -              | -              | Select + R1  | -            |
 | Full Screen     | -              | -              | L4       | -              | -              | -            | -            |

--- a/configs/net.pcsx2.PCSX2/config/PCSX2/inis/PCSX2_keys.ini
+++ b/configs/net.pcsx2.PCSX2/config/PCSX2/inis/PCSX2_keys.ini
@@ -39,7 +39,7 @@ States_CycleSlotForward           = F2
 States_CycleSlotBackward          = Shift-F2
 
 Frameskip_Toggle                  = Shift-F4
-Framelimiter_TurboToggle          = Shift-M
+Framelimiter_TurboToggle          = TAB
 Framelimiter_SlomoToggle          = Shift-TAB
 Framelimiter_MasterToggle         = F4
 

--- a/configs/steam-input/pcsx2_controller_config.vdf
+++ b/configs/steam-input/pcsx2_controller_config.vdf
@@ -803,7 +803,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press S"
+							"binding"		"key_press TAB"
 						}
 					}
 				}


### PR DESCRIPTION
### Summary

- Resolves PCSX2 TurboMode (FFWD/Fast Forward) Keybinds as shift+m wasn't functioning
- Utilizes R4 (by default was S) as S was not used in PCSX2
- Update README to correctly reflect this change