### PR TITLE
Adds GitHub Actions linting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,3 +39,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@v1.0
+  toml-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: TOML linter
+        uses: yisonPylkita/gh-action-toml-linter@0.1.3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        # env:
+          # SHELLCHECK_OPTS: -e SC2059 -e SC2034 -e SC1090 -e SC2164 -e SC1091

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,12 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         # env:
           # SHELLCHECK_OPTS: -e SC2059 -e SC2034 -e SC1090 -e SC2164 -e SC1091
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: shfmt
+        uses: collin-miller/shfmt-action@v1
   markdownlint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: shfmt
         uses: collin-miller/shfmt-action@v1
+        with:
+          args: -d .
   markdownlint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, beta, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [main, beta, dev]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -17,14 +17,6 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         # env:
           # SHELLCHECK_OPTS: -e SC2059 -e SC2034 -e SC1090 -e SC2164 -e SC1091
-  shfmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: shfmt
-        uses: collin-miller/shfmt-action@v1
-        with:
-          args: -d .
   markdownlint:
     runs-on: ubuntu-latest
     steps:
@@ -39,9 +31,3 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@v1.0
-  toml-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: TOML linter
-        uses: yisonPylkita/gh-action-toml-linter@0.1.3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,4 +25,9 @@ jobs:
         uses: nosborn/github-action-markdown-cli@v3.1.0
         with:
           files: .
-
+  PSScriptAnalyzer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run PSScriptAnalyzer
+        uses: microsoft/psscriptanalyzer-action@v1.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,3 +17,9 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         # env:
           # SHELLCHECK_OPTS: -e SC2059 -e SC2034 -e SC1090 -e SC2164 -e SC1091
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.1.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,3 +23,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.1.0
+        with:
+          files: .
+


### PR DESCRIPTION
Unsure if this is something this project wants, but I finally got some time to work on this and threw together some GitHub Actions CI jobs real quick.

Adds GHA lint jobs for:
- `.sh` with shellcheck & shfmt
- `.md` with markdownlint
- `.ps1` with PSScriptAnalyzer

I've got a [summary of a demo run here](https://github.com/DylanTackoor/EmuDeck/actions/runs/2480499236). Assuming some CI jobs like this are wanted, I could start fixing the shellscript lint errors and provide hosting for the GHA runners.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/5377356/173196307-2e887261-a457-4181-9a8e-ead41eb61159.png">

I'd also need to check if the powershell linting is actually working as I've only touched ps scripts once before 🙃 