### PR TITLE
WiiU steam-rom-manager glob update

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -1691,7 +1691,7 @@
       "useCredentials": true
     },
     "parserInputs": {
-      "glob": "${title}@(7z|7Z|.zip|.ZIP|wux|wud|wua|wad|iso)"
+      "glob": "${title}@(.7z|.7Z|.zip|.ZIP|.wux|.WUX|.wud|.WUD|.wua|.WUA|.wad|.WAD|.iso|.ISO)"
     },
     "titleFromVariable": {
       "limitToGroups": "",


### PR DESCRIPTION
Previously was missing the period in the extensions and was only looking for lower case.