### PR TITLE
CHDDeck now finds and removes files from gdi and cue

### DIFF
--- a/tools/chdconv/chddeck.sh
+++ b/tools/chdconv/chddeck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-text="`printf "<b>Hi</b>\nWelcome to EmuDeck's CHD conversion script!\n\nThis is currently a <b>BETA</b> feature. Please be very careful and make sure you have backups of roms.\n\nThis script will scan the roms folder you choose and convert all your .cue/.bin and .gdi files to the superior CHD format.\n\n<b>This action will delete the old files if the conversion to chd succeeds</b>"`"
+text="$(printf "<b>Hi</b>\nWelcome to EmuDeck's CHD conversion script!\n\nThis is currently a <b>BETA</b> feature. Please be very careful and make sure you have backups of roms.\n\nThis script will scan the roms folder you choose and convert all your .cue/.bin and .gdi files to the superior CHD format.\n\n<b>This action will delete the old files if the conversion to chd succeeds</b>")"
 #Nova fix'
 zenity --question \
 		 --title="EmuDeck" \
@@ -10,54 +10,55 @@ zenity --question \
 		 --text="${text}" 2>/dev/null
 ans=$?
 if [ $ans -eq 0 ]; then
-	
+
 
 	#paths update via sed in main script
 	romsPath="/run/media/mmcblk0p1/Emulation/roms/"
 	toolsPath="/run/media/mmcblk0p1/Emulation/tools/"
 	chdPath="${toolsPath}chdconv/"
-	
-	
+
+
 	#initialize log
-	TIMESTAMP=`date "+%Y%m%d_%H%M%S"`
+	TIMESTAMP=$(date "+%Y%m%d_%H%M%S")
 	LOGFILE="$chdPath/chdman-$TIMESTAMP.log"
-	exec > >(tee ${LOGFILE}) 2>&1
-	
+	exec > >(tee "${LOGFILE}") 2>&1
+
 
 	#ask user if they want to pick manually or run a search for eligible files. Manual will need to ask the user to pick a file, and then it will need to ask the type to convert to. (chd, rvz, cso)
 
 
 	echo "Checking $romsPath for files eligible for conversion."
-	
+
 	#whitelist
 	declare -a chdfolderWhiteList=("dreamcast" "psx" "segacd" "3do" "saturn" "tg-cd" "pcenginecd" "pcfx" "amigacd32" "neogeocd" "megacd" "ps2")
 	declare -a rvzfolderWhiteList=("gamecube" "wii")
 	declare -a searchFolderList
-    echo $chdfolderWhiteList
+
 	export PATH="${chdPath}/:$PATH"
 
 	#find file types we support within whitelist of folders
 	for romfolder in ${chdfolderWhiteList[@]}; do
 		echo "Checking ${romsPath}${romfolder}/"
-		files=(`find "${romsPath}${romfolder}/" -type f -iname "*.gdi" -o -type f -iname "*.cue" -o -type f -iname "*.iso"`)
-		if [ ${#files[@]} -gt 0 ]; then 
-			echo "found in $romfolder"
-			searchFolderList+=("$romfolder")
-		fi
-	done
-
-    for romfolder in ${rvzfolderWhiteList[@]}; do
-		echo "Checking ${romsPath}${romfolder}/"
-		files=(`find "${romsPath}${romfolder}/" -type f -iname "*.gcm"  -o -type f -iname "*.iso"`)
+		files=($(find "${romsPath}${romfolder}/" -type f -iname "*.gdi" -o -type f -iname "*.cue" -o -type f -iname "*.iso"))
 		if [ ${#files[@]} -gt 0 ]; then
 			echo "found in $romfolder"
 			searchFolderList+=("$romfolder")
 		fi
 	done
-	
+	if [[ -f "/var/lib/flatpak/app/org.DolphinEmu.dolphin-emu/current/active/files/bin/dolphin-tool" ]]; then #ensure tools are in place
+        for romfolder in ${rvzfolderWhiteList[@]}; do
+            echo "Checking ${romsPath}${romfolder}/"
+            files=($(find "${romsPath}${romfolder}/" -type f -iname "*.gcm"  -o -type f -iname "*.iso"))
+            if [ ${#files[@]} -gt 0 ]; then
+                echo "found in $romfolder"
+                searchFolderList+=("$romfolder")
+            fi
+        done
+    fi
+
 	if (( ${#searchFolderList[@]} == 0 )); then
 		echo "No eligible files found."
-		text="`printf "<b>No suitable roms were found for conversion.</b>\n\nPlease check if you have any cue / gdi / iso files for compatible systems."`"
+		text="$(printf "<b>No suitable roms were found for conversion.</b>\n\nPlease check if you have any cue / gdi / iso files for compatible systems.")"
 		zenity --error \
 		 --title="EmuDeck" \
 		 --width=250 \
@@ -68,9 +69,9 @@ if [ $ans -eq 0 ]; then
 
 
 	declare -i height=(${#searchFolderList[@]}*100)
-	selectColumnStr="RomFolder " 
+	selectColumnStr="RomFolder "
 	for (( i=1; i<=${#searchFolderList[@]}; i++ )); do selectColumnStr+="$i ${searchFolderList[$i-1]} " ; done
-	text="`printf "What folders do you want to convert?"`"
+	text="$(printf "What folders do you want to convert?")"
 	folderstoconvert=$(zenity --list \
 				--title="EmuDeck" \
 				--height=$height \
@@ -82,9 +83,9 @@ if [ $ans -eq 0 ]; then
 				--column="" \
 				--column=${selectColumnStr})
 				echo "User selected $folderstoconvert" 2>/dev/null
-	
+
 	IFS="|" read -r -a romfolders <<< "$folderstoconvert"
-	
+
 	#query user about FileTypes? maybe they only want to convert bin/cue? Iso? Gdi?
 	#check list here?
 
@@ -100,23 +101,63 @@ if [ $ans -eq 0 ]; then
 	#CHD
 	for romfolder in ${romfolders[@]}; do
         if [[ " ${chdfolderWhiteList[*]} " =~ " ${romfolder} " ]]; then
-            find "$romsPath$romfolder" -type f -iname "*.cue" | while read f; do echo "Converting: $f"; chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "$f" && rm -rf "${f%.*}.bin"; done;
-            find "$romsPath$romfolder" -type f -iname "*.gdi" | while read f; do echo "Converting: $f"; chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "$f"; done; #going to need work
+
+            find "$romsPath$romfolder" -type f -iname "*.gdi" | while read f
+                do
+                    echo "Converting: $f"
+                    CUEDIR="$(dirname "${f}")"
+                    chdman5 createcd -i "$f" -o "${f%.*}.chd" && successful="true"
+                    if [[ $successful == "true" ]]; then
+                        echo "successfully created ${f%.*}.chd"
+                        find "${CUEDIR}" -maxdepth 1 -type f | while read b
+                            do
+                                fileName="$(basename "${b}")"
+                                found=$(grep "${fileName}" "${f}")
+                                if [[ ! $found = '' ]]; then
+                                    echo "Deleting ${b}"
+                                    rm "${b}"
+                                fi
+                            done
+                            rm "${f}"
+                    else
+                        echo "Conversion of ${f} failed."
+                    fi
+
+                done
+            find "$romsPath$romfolder" -type f -iname "*.cue" | while read f
+                do
+                    echo "Converting: $f"
+                    CUEDIR="$(dirname "${f}")"
+                    chdman5 createcd -i "$f" -o "${f%.*}.chd" && successful="true"
+                    if [[ $successful == "true" ]]; then
+                        echo "successfully created ${f%.*}.chd"
+                        find "${CUEDIR}" -maxdepth 1 -type f | while read b
+                            do
+                                fileName="$(basename "${b}")"
+                                found=$(grep "${fileName}" "${f}")
+                                if [[ ! $found = '' ]]; then
+                                    echo "Deleting ${b}"
+                                    rm "${b}"
+                                fi
+                            done
+                            rm "${f}"
+                    else
+                        echo "Conversion of ${f} failed."
+                    fi
+
+                done
             find "$romsPath$romfolder" -type f -iname "*.iso" | while read f; do echo "Converting: $f"; chdman5 createcd -i "$f" -o "${f%.*}.chd" && rm -rf "$f"; done;
         fi
 	done
 
 	#rvz
-	if [[ -f "${toolsPath}proton-launch.sh" && -f "${chdPath}DolphinTool.exe" ]]; then #ensure tools are in place
-		for romfolder in ${romfolders[@]}; do
-			if [[ " ${rvzfolderWhiteList[*]} " =~ " ${romfolder} " ]]; then
-				find "$romsPath$romfolder" -type f -iname "*.iso" | while read f; do echo "Converting: $f"; ${toolsPath}proton-launch.sh ${chdPath}DolphinTool.exe convert -f rvz -b 131072 -c zstd -l 5 -i "z:$f" -o "z:${f%.*}.rvz"  && rm -rf "$f"; done;
-				find "$romsPath$romfolder" -type f -iname "*.gcm" | while read f; do echo "Converting: $f"; ${toolsPath}proton-launch.sh ${chdPath}DolphinTool.exe convert -f rvz -b 131072 -c zstd -l 5 -i "z:$f" -o "z:${f%.*}.rvz"  && rm -rf "$f"; done;
-			fi
-		done
-	else
-		echo "missing tools"
-	fi
+
+    for romfolder in ${romfolders[@]}; do
+        if [[ " ${rvzfolderWhiteList[*]} " =~ " ${romfolder} " ]]; then
+            find "$romsPath$romfolder" -type f -iname "*.gcm"  -o -type f -iname "*.iso" | while read f; do echo "Converting: $f"; /var/lib/flatpak/app/org.DolphinEmu.dolphin-emu/current/active/files/bin/dolphin-tool convert -f rvz -b 131072 -c zstd -l 5 -i "z:$f" -o "z:${f%.*}.rvz"  && rm -rf "$f"; done;
+        fi
+    done
+
 	#cso
 	#
 
@@ -124,7 +165,7 @@ else
 	exit
 fi
 
-text="`printf "<b>Done!</b>\n\n If you use Steam Rom Manager to catalog your games you will need to open it now to update your games"`"
+text="$(printf "<b>Done!</b>\n\n If you use Steam Rom Manager to catalog your games you will need to open it now to update your games")"
 zenity --question \
 		 --title="EmuDeck" \
 		 --width=450 \

--- a/tools/chdconv/chddeck.sh
+++ b/tools/chdconv/chddeck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-text="$(printf "<b>Hi</b>\nWelcome to EmuDeck's CHD conversion script!\n\nThis is currently a <b>BETA</b> feature. Please be very careful and make sure you have backups of roms.\n\nThis script will scan the roms folder you choose and convert all your .cue/.bin and .gdi files to the superior CHD format.\n\n<b>This action will delete the old files if the conversion to chd succeeds</b>")"
+text="$(printf "<b>Hi</b>\nWelcome to EmuDeck's Game Compression script!\n\nPlease be very careful and make sure you have backups of roms.\n\nThis script will scan the roms folder you choose and will compress the files it can to the best available format.\n\n<b>This action will delete the old files if the compression succeeds</b>")"
 #Nova fix'
 zenity --question \
 		 --title="EmuDeck" \
@@ -154,7 +154,7 @@ if [ $ans -eq 0 ]; then
 
     for romfolder in ${romfolders[@]}; do
         if [[ " ${rvzfolderWhiteList[*]} " =~ " ${romfolder} " ]]; then
-            find "$romsPath$romfolder" -type f -iname "*.gcm"  -o -type f -iname "*.iso" | while read f; do echo "Converting: $f"; /var/lib/flatpak/app/org.DolphinEmu.dolphin-emu/current/active/files/bin/dolphin-tool convert -f rvz -b 131072 -c zstd -l 5 -i "z:$f" -o "z:${f%.*}.rvz"  && rm -rf "$f"; done;
+            find "$romsPath$romfolder" -type f -iname "*.gcm"  -o -type f -iname "*.iso" | while read f; do echo "Converting: $f"; /var/lib/flatpak/app/org.DolphinEmu.dolphin-emu/current/active/files/bin/dolphin-tool convert -f rvz -b 131072 -c zstd -l 5 -i "$f" -o "${f%.*}.rvz"  && rm -rf "$f"; done;
         fi
     done
 


### PR DESCRIPTION
deleted dolphintool.exe in favor of dolphin-tool in the flatpak binary dir.
Fixes: #216
Fixes: #103 