### PR TITLE
Mupen64Plus-Next: Changed default controller pak back to "memory"

### DIFF
--- a/functions/EmuScripts/emuDeckRetroArch.sh
+++ b/functions/EmuScripts/emuDeckRetroArch.sh
@@ -944,7 +944,7 @@ RetroArch_Mupen64Plus_Next_setUpCoreOpt(){
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-OverscanLeft' '"0"'
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-OverscanRight' '"0"'
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-OverscanTop' '"0"'
-	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-pak1' '"rumble"'
+	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-pak1' '"memory"'
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-pak2' '"none"'
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-pak3' '"none"'
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-pak4' '"none"'


### PR DESCRIPTION
As discussed in #294:

> With a rumble pak, saving games is not possible. IMO, the default configuration should at least allow people to have saves.
This was introduced in https://github.com/dragoonDorise/EmuDeck/commit/6faa114051d204ee92fd26887bdac5620d46a45e.

> I would rather have saving work out of the box without having to use save states than rumble. This is, however, personal preference.
I also believe having to use save states is rather unintuitive for new and non-tech-savvy users, who might not know about them or the needed keybinds. For these users, having the memory pak enabled would most likely improve the out-of-the-box experience.