### PR TITLE
Fix: Change cemu appid to fix launch issues

### DIFF
--- a/tools/launchers/cemu.sh
+++ b/tools/launchers/cemu.sh
@@ -8,4 +8,4 @@ PROTONLAUNCH="/run/media/mmcblk0p1/Emulation/tools/proton-launch.sh"
 CEMU="/run/media/mmcblk0p1/Emulation/roms/wiiu/Cemu.exe"
 
 # Call the Proton launcher script and give the arguments
-"${PROTONLAUNCH}" -p '7.0' -- "${CEMU}" "${@}"
+"${PROTONLAUNCH}" -i '10000' -p '7.0' -- "${CEMU}" "${@}"


### PR DESCRIPTION
Using appid 0 can cause cemu to fail to launch correctly on some systems. Changing the appid directory has reportedly fixed this for multiple users, including myself