### PR TITLE
adds labels to citra's grip button mappings

### DIFF
--- a/configs/steam-input/citra_controller_config.vdf
+++ b/configs/steam-input/citra_controller_config.vdf
@@ -694,7 +694,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press E"
+							"binding"		"key_press E, Layout Toggle"
 						}
 					}
 				}
@@ -710,7 +710,7 @@
 					{
 						"bindings"
 						{
-							"binding"        "key_press X"
+							"binding"        "key_press X, Hold to Quit"
 						}
 						"settings"
 						{
@@ -730,7 +730,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press F"
+							"binding"		"key_press F, Fullscreen Toggle"
 						}
 					}
 				}
@@ -746,7 +746,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press S"
+							"binding"		"key_press S, Swap Screens"
 						}
 					}
 				}


### PR DESCRIPTION
Labels the grip buttons in the Citra config 😄
![7_20220818232951_1](https://user-images.githubusercontent.com/5377356/185536935-92114859-c729-4256-8fe0-46d2321ae99f.png)
![7_20220818232958_1](https://user-images.githubusercontent.com/5377356/185536946-95d7cf1b-7a51-4a23-8fc6-f006df093074.png)
 