### PR TITLE
proton-launch.sh - Catch some common argument errors

### DIFF
--- a/tools/proton-launch.sh
+++ b/tools/proton-launch.sh
@@ -51,7 +51,10 @@ set_env () {
     fi
     # Create prefix if it doesn't exist
     if ! [ -d "${STEAM_COMPAT_DATA_PATH}" ]; then
-        install -d "${STEAM_COMPAT_DATA_PATH}" || exit 1
+        install -d "${STEAM_COMPAT_DATA_PATH}" || {
+            echo "Error: Failed to create STEAM_COMPAT_DATA_PATH: ${STEAM_COMPAT_DATA_PATH}" >> "${LOGFILE}"
+            exit 1 # Output this error
+        }
     fi
     {
         echo "STEAM_COMPAT_DATA_PATH: ${STEAM_COMPAT_DATA_PATH}"

--- a/tools/proton-launch.sh
+++ b/tools/proton-launch.sh
@@ -51,9 +51,12 @@ set_env () {
     fi
     # Create prefix if it doesn't exist
     if ! [ -d "${STEAM_COMPAT_DATA_PATH}" ]; then
-        install -d "${STEAM_COMPAT_DATA_PATH}" || {
-            echo "Error: Failed to create STEAM_COMPAT_DATA_PATH: ${STEAM_COMPAT_DATA_PATH}" >> "${LOGFILE}"
-            exit 1 # Output this error
+        installOutput="$( install -d "${STEAM_COMPAT_DATA_PATH}" )" || {
+            {
+                echo "Error: Failed to create STEAM_COMPAT_DATA_PATH: ${STEAM_COMPAT_DATA_PATH}"
+                echo "Error: ${installOutput}"
+            } >> "${LOGFILE}"
+            exit 1
         }
     fi
     {


### PR DESCRIPTION
Moved the shift of the options out of the arguments to make more sense

Added `showArguments` to output all arguments to help with troubleshooting

Added an integer check for the `-i` option.