### PR TITLE
[appID.py] Exit immediately if arguments are not 3

### DIFF
--- a/tools/appID.py
+++ b/tools/appID.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python
 
-# We need binascii to convert the path and app name to crc32 and sys to get the command line arguments
+# We need binascii to convert the path and app name to crc32 and sys to
+# get the command line arguments
 import binascii
 import sys
+
 
 def get_app_id(exe, appname):
     """Get APP ID for non-steam shortcut.
@@ -14,6 +16,7 @@ def get_app_id(exe, appname):
     
     return id_int
 
+
 def main():
     """Get the two arguments and send them to get_app_id"""
     exe = sys.argv[1]
@@ -21,11 +24,9 @@ def main():
 
     print(get_app_id(exe, appname))
 
+
 if __name__ == "__main__":
-    # Make sure we have sufficient arguments
-    if len(sys.argv) == 3:
-        # Run main()
-        main()
     # If there aren't the correct number of arguments, fail with error
-    else:
-        exit(1)
+    if len(sys.argv) != 3:
+        sys.exit("Not enough arguments")
+    main()


### PR DESCRIPTION
Using sys.exit will actually exit from the python interpreter, while exit may require user interaction.
Also save a little time as there's no need for an else statement.