### PR TITLE
Fix #479 - Don't expand on command

### DIFF
--- a/functions/EmuScripts/emuDeckRetroArch.sh
+++ b/functions/EmuScripts/emuDeckRetroArch.sh
@@ -1921,8 +1921,8 @@ RetroArch_retroAchievementsPromptLogin(){
 	fi
 }
 RetroArch_retroAchievementsSetLogin(){
-	rap=$(cat "$HOME/.config/EmuDeck/.rap")
-	rau=$(cat "$HOME/.config/EmuDeck/.rau")
+	rap="$( cat "${HOME}/.config/EmuDeck/.rap" )"
+	rau="$( cat "${HOME}/.config/EmuDeck/.rau" )"
 	echo "Evaluate RetroAchievements Login."
 	if [ ${#rap} -lt 1 ]; then
 		echo "--No password."

--- a/tools/launchers/cemu.sh
+++ b/tools/launchers/cemu.sh
@@ -64,6 +64,9 @@ if [ -z "${APPID}" ]; then
     reportError "Unable to calculate AppID" "true" "true"
 fi
 
+# PROTONVER
+PROTONVER="7.0"
+
 # Call the Proton launcher script and give the arguments
-echo "${PROTONLAUNCH}" -p '7.0' -i "${APPID}" -- "${CEMU}" "${@}" >> "${LOGFILE}"
-"${PROTONLAUNCH}" -p '7.0' -i "${APPID}" -- "${CEMU}" "${@}"
+echo "${PROTONLAUNCH}" -p "${PROTONVER}" -i "${APPID}" -- "${CEMU}" "${@}" >> "${LOGFILE}"
+"${PROTONLAUNCH}" -p "${PROTONVER}" -i "${APPID}" -- "${CEMU}" "${@}"

--- a/tools/launchers/xenia.sh
+++ b/tools/launchers/xenia.sh
@@ -64,6 +64,9 @@ if [ -z "${APPID}" ]; then
     reportError "Unable to calculate AppID" "true" "true"
 fi
 
+# PROTONVER
+PROTONVER="7.0"
+
 # Call the Proton launcher script and give the arguments
-echo "${PROTONLAUNCH}" -p '7.0' -i "${APPID}" -- "${XENIA}" "${@}" >> "${LOGFILE}"
-"${PROTONLAUNCH}" -p '7.0' -i "${APPID}" -- "${XENIA}" "${@}"
+echo "${PROTONLAUNCH}" -p "${PROTONVER}" -i "${APPID}" -- "${XENIA}" "${@}" >> "${LOGFILE}"
+"${PROTONLAUNCH}" -p "${PROTONVER}" -i "${APPID}" -- "${XENIA}" "${@}"

--- a/tools/proton-launch.sh
+++ b/tools/proton-launch.sh
@@ -102,7 +102,7 @@ findProton () {
     if [ -z ${proton+x} ]; then
         # Report to log but don't error to user
         reportError "Error: Unable to find Proton version ${1}."
-        # Check if an install was already attempted, if not, attempt
+        # Attempt to install Proton version
         installProton "${1}"
     else
         # Return found proton path

--- a/tools/proton-launch.sh
+++ b/tools/proton-launch.sh
@@ -4,12 +4,15 @@
 
 # Report Errors
 reportError () {
+    # Report error to logfile
     echo "${1}" >> "${LOGFILE}"
+    # Open a Zenity dialog for the user
     if [ "${2}" == "true" ]; then
         zenity --error \
             --text="${1}"\
             --width=250
     fi
+    # Exit the script
     if [ "${3}" == "true" ]; then
         exit 1
     fi
@@ -45,6 +48,66 @@ showArguments () {
     for arg; do
         echo "Argument:  $arg" >> "${LOGFILE}"
     done
+}
+
+# Attempt to send a request to install Proton version
+installProton () {
+    # Known AppIDs for Proton versions
+    declare -A protonVersions=(
+        [3.7 Beta]="930400"
+        [3.7]="858280"
+        [3.16 Beta]="996510"
+        [3.16]="961940"
+        [4.2]="1054830"
+        [4.11]="1113280"
+        [5.0]="1245040"
+        [5.13]="1420170"
+        [6.3]="1580130"
+        [7.0]="1887720"
+        [- Experimental]="1493710"
+        [Hotfix]="2180100"
+        [EasyAntiCheat Runtime]="1826330"
+        [BattlEye Runtime]="1161040"
+    )
+
+    # If Proton Version is known, attempt to prompt the user to install it
+    if [ "${protonVersions[${1}]+x}" ]; then
+        {
+            reportError "Attempting to install Proton ${1}." "true"
+            # Send install command to Steam
+            steam steam://install/"${protonVersions[${1}]}"
+            # Steam won't download until the script is closed.
+            reportError "Please re-open after Proton ${1} has been installed." "true" "true"
+        } >> "${LOGFILE}"
+    else
+        # Exit with error if the Proton version is unknown
+        reportError "Error: Unknown Proton version ${1}." "true" "true"
+    fi 
+}
+
+# Find Proton version
+findProton () {
+    # Cycle through steamPaths to find the requested Proton version
+    for path in "${steamPaths[@]}"; do
+        if [ -f "${path}/steamapps/common/Proton ${1}/proton" ]; then
+            local proton="${path}/steamapps/common/Proton ${1}/proton"
+            break
+        elif [ -f "${path}/compatabilitytools.d/${1}/proton" ]; then
+            local proton="${path}/compatabilitytools.d/${1}/proton"
+            break
+        fi
+    done
+
+    # Check if the proton variable was successfully set
+    if [ -z ${proton+x} ]; then
+        # Report to log but don't error to user
+        reportError "Error: Unable to find Proton version ${1}."
+        # Check if an install was already attempted, if not, attempt
+        installProton "${1}"
+    else
+        # Return found proton path
+        echo "${proton}"
+    fi
 }
 
 # Set environment variables
@@ -91,20 +154,24 @@ set_env () {
 main () {
     # Report all $@ to LOGFILE for troubleshooting
     showArguments "${@}"
-    
-    # Steam Application Path
-    if [ -d "${HOME}/.local/share/Steam" ]; then
-        STEAMPATH="${HOME}/.local/share/Steam"
-        echo "STEAMPATH: ${STEAMPATH}" >> "${LOGFILE}"
-    else # Fail if Steam path isn't a directory
-        reportError "Steam path not found." "true" "true"
+
+    # Get all available Steam paths
+    steamLibraryFolders="${HOME}/.local/share/Steam/steamapps/libraryfolders.vdf"
+    if [ -f "${steamLibraryFolders}" ]; then
+        # shellcheck disable=SC2207
+        steamPaths=( $( grep path "${steamLibraryFolders}" | awk '{print $2}' | sed 's|\"||g' ) )
+        {
+            echo "Steam Paths:"
+            for path in "${steamPaths[@]}"; do
+                echo "${path}"
+            done
+        } >> "${LOGFILE}"
+    else
+        reportError "Error: ${steamLibraryFolders} is not a file." "true" "true"
     fi
 
-    # Alt steamapps path - need a way to pull all available steamapps directories own by Steam
-    if [ -d "/run/media/mmcblk0p1/steamapps" ]; then
-        ALTSTEAM="/run/media/mmcblk0p1/steamapps"
-        echo "ALTSTEAM: ${ALTSTEAM}" >> "${LOGFILE}"
-    fi
+    STEAMPATH="${steamPaths[1]}"
+    echo "STEAMPATH: ${STEAMPATH}" >> "${LOGFILE}"
 
     # Check for options -h help -p Proton Version -i AppID
     while getopts "h:p:i:" option; do
@@ -114,38 +181,7 @@ main () {
                 echo "Help flag was called." >> "${LOGFILE}"
                 exit;;
             p) # Proton version
-                PROTONVER="${OPTARG}"
-                # Check for Proton paths
-                if [ -f "${STEAMPATH}/steamapps/common/Proton ${PROTONVER}/proton" ]; then
-                    PROTON="${STEAMPATH}/steamapps/common/Proton ${PROTONVER}/proton"
-                    COMPATDATA="${STEAMPATH}/steamapps/compatdata"
-                    {
-                        echo "Proton Version: ${PROTONVER}"
-                        echo "Proton Path: ${PROTON}" 
-                        echo "COMPATDATA: ${COMPATDATA}" 
-                    } >> "${LOGFILE}"
-                # Check for Custom Proton paths
-                elif [ -f "${STEAMPATH}/compatibilitytools.d/${PROTONVER}/proton" ]; then
-                    PROTON="${STEAMPATH}/compatibilitytools.d/${PROTONVER}/proton"
-                    COMPATDATA="${STEAMPATH}/steamapps/compatdata"
-                    {
-                        echo "Proton Version: ${PROTONVER}"
-                        echo "Proton Path: ${PROTON}" 
-                        echo "COMPATDATA: ${COMPATDATA}" 
-                    } >> "${LOGFILE}"
-                # If we can't find the default path, try the alternate one - loop here through all Steamapps?
-                elif [ -n "${ALTSTEAM}" ] && [ -f "${ALTSTEAM}/common/Proton ${PROTONVER}/proton" ]; then
-                    PROTON="${ALTSTEAM}/common/Proton ${PROTONVER}/proton"
-                    COMPATDATA="${ALTSTEAM}/compatdata"
-                    {
-                        echo "Proton Version: ${PROTONVER}"
-                        echo "Proton Path: ${PROTON}" 
-                        echo "COMPATDATA: ${COMPATDATA}" 
-                    } >> "${LOGFILE}"
-                # Couldn't find either path
-                else
-                    reportError "Error: Proton version ${PROTONVER} is not installed." "true" "true"
-                fi;;
+                PROTONVER="${OPTARG}";;
             i) # Proton AppID
                 APPID="${OPTARG}"
                 # Check for non-integer option arguments
@@ -162,10 +198,17 @@ main () {
     # Remove opt arguments from $@ before --
     shift "$(( OPTIND - 1 ))"
 
-    # Make sure there were any odd arguments in the options
+    # Make sure there weren't any odd arguments in the options
     if [[ "${*}" == *"--"* ]]; then
         echo "Error: Invalid argument in options." >> "${LOGFILE}"
         exit 1
+    fi
+
+    # Check for mandatory target
+    if [ -z ${1+x} ]; then
+        reportError "Error: Target application must be set." "true" "true"
+    elif ! [ -f "${1}" ]; then
+        reportError "Target application not found. - ${1}" "true" "true"
     fi
 
     # Check if AppID is set, if not, set it to 0
@@ -176,45 +219,31 @@ main () {
         reportError "Error: AppID must be an integer" "true" "true"
     fi
 
-    # Check if Proton is set, if not, set it to 7.0 by default
-    if [ -z ${PROTON+x} ] && [ -f "${STEAMPATH}/steamapps/common/Proton 7.0/proton" ]; then
-        PROTON="${STEAMPATH}/steamapps/common/Proton 7.0/proton"
-        PFX="${STEAMPATH}/steamapps/compatdata/${APPID}"
-        echo "Proton: ${PROTON}" >> "${LOGFILE}"
-        echo "PFX: ${PFX}" >> "${LOGFILE}"
-    # Try the Alt directory - loop here?
-    elif [ -z ${PROTON+x} ] && [ -n "${ALTSTEAM}" ] && [ -f "${ALTSTEAM}/common/Proton 7.0/proton" ]; then
-        PROTON="${ALTSTEAM}/common/Proton 7.0/proton"
-        PFX="${ALTSTEAM}/compatdata/${APPID}"
-        echo "Proton: ${PROTON}" >> "${LOGFILE}"
-        echo "PFX: ${PFX}" >> "${LOGFILE}"
+    # Check if Proton version is set, if not, set it to 7.0 by default
+    if [ -z ${PROTONVER+x} ]; then
+        PROTONVER="7.0"
     fi
 
-    # Cancel if PROTON is still not set.
-    if [ -z ${PROTON+x} ]; then
-        reportError "Error: Proton is not set." "true" "true"
-    fi
+    # Find set Proton version
+    PROTON="$( findProton "${PROTONVER}" )"
 
-    # Set PFX if not set
-    if [ -z ${PFX+x} ] && [ -n "${COMPATDATA}" ]; then
-        PFX="${COMPATDATA}/${APPID}"
-        echo "PFX: ${PFX}" >> "${LOGFILE}"
-    elif [ -z ${PFX+x} ]; then
-        echo "No PFX." >> "${LOGFILE}"
-    fi
+    # Set COMPATDATA directory
+    COMPATDATA="${STEAMPATH}/steamapps/compatdata"
 
-    # Check for mandatory target
-    if [ -z ${1+x} ]; then
-        reportError "Error: Target application must be set." "true" "true"
-    elif ! [ -f "${1}" ]; then
-        reportError "Target application not found. - ${1}" "true" "true"
-    fi
+    # Set PFX - should always be in the first path
+    PFX="${COMPATDATA}/${APPID}"
+
+    {
+        echo "Proton: ${PROTON}"
+        echo "PFX: ${PFX}"
+        echo "COMPATDATA: ${COMPATDATA}"
+    } >> "${LOGFILE}"
     
     # Call set_env function
     set_env
 
     # Start application with Proton
-    echo "Running python ${PROTON} waitforexitandrun $*" >> "${LOGFILE}" # Send command to log just in case
+    echo "Running python ${PROTON} waitforexitandrun ${*}" >> "${LOGFILE}" # Send command to log just in case
     python "${PROTON}" waitforexitandrun "${@}"
 }
 


### PR DESCRIPTION
Prevent parameter expansion on username and password for Retro Achievements

Shell expands output from commands in "$( )" and "\` \`" by default. Close command substitutions in quotes to prevent this.

This does not interfere with quotes inside the command substitution.

```bash
rap=$(cat "${HOME}/.config/EmuDeck/.rap")
rau=$(cat "${HOME}/.config/EmuDeck/.rau")
```

```bash
rap="$( cat "${HOME}/.config/EmuDeck/.rap" )"
rau="$( cat "${HOME}/.config/EmuDeck/.rau" )"
```

