### PR TITLE
Explicitely call bash instead of /bin/sh

### DIFF
--- a/tools/remoteplaywhatever/remoteplaywhatever.sh
+++ b/tools/remoteplaywhatever/remoteplaywhatever.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 	 text="`printf " <b>Multiplayer Instructions</b>\n\n Invite your friend on the next window\n\nPress the STEAM Button and go back to Library, open <b>EmulationStation</b>, launch your game and enjoy!!\n\nAs of now only games launched using EmulationStation work on Multiplayer mode\n\n<b>RemotePlayWhatever is in early beta, so expecto some crashes here and there</b>)"`"
  zenity --info \
@@ -7,3 +7,4 @@
 		 --text="${text}" 2>/dev/null	
 
 ~/Applications/RemotePlayWhatever.AppImage
+

--- a/tools/updater/emudeck-updater.sh
+++ b/tools/updater/emudeck-updater.sh
@@ -1,2 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 ~/Applications/EmuDeck.AppImage --isGameMode
+


### PR DESCRIPTION
The /bin/sh file is a link, not an actual binary, and that can point to /bin/bash as well as other shells, like /bin/dash in recent ubuntu versions.
To be consistent between linux distributions, and avoid issues like missing support for bash functions (e.g. source), let's call /bin/bash instead.