### PR TITLE
add sysdata symlink to bios folder for citra

### DIFF
--- a/functions/EmuScripts/emuDeckCitra.sh
+++ b/functions/EmuScripts/emuDeckCitra.sh
@@ -45,6 +45,10 @@ Citra_setEmulationFolder(){
     gameDirOpt='Paths\\gamedirs\\3\\path='
     newGameDirOpt='Paths\\gamedirs\\3\\path='"${romsPath}/3ds"
     sed -i "/${gameDirOpt}/c\\${newGameDirOpt}" "$configFile"
+
+	#Setup symlink for AES keys
+	mkdir -p "${biosPath}/citra/"
+    ln -sn "$HOME/.var/app/org.citra_emu.citra/data/citra-emu/sysdata" "${biosPath}/citra/keys"
 }
 
 #SetupSaves

--- a/functions/EmuScripts/emuDeckCitra.sh
+++ b/functions/EmuScripts/emuDeckCitra.sh
@@ -48,6 +48,7 @@ Citra_setEmulationFolder(){
 
 	#Setup symlink for AES keys
 	mkdir -p "${biosPath}/citra/"
+	mkdir -p "$HOME/.var/app/org.citra_emu.citra/data/citra-emu/sysdata"
     ln -sn "$HOME/.var/app/org.citra_emu.citra/data/citra-emu/sysdata" "${biosPath}/citra/keys"
 }
 


### PR DESCRIPTION
Quick symlink based on Ryujinx script to add the folder needed to store AES keys into the bios folder