### PR TITLE
Fix ryujinx's steam category to be in the same format as yuzu's

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2937,8 +2937,8 @@
   },
   {
     "parserType": "Glob",
-    "configTitle": "Nintendo Switch Ryujinx",
-    "steamCategory": "${Switch - Ryujinx}",
+    "configTitle": "Nintendo Switch - Ryujinx",
+    "steamCategory": "${Nintendo Switch - Ryujinx}",
     "steamDirectory": "/home/deck/.steam/steam",
     "romDirectory": "/run/media/mmcblk0p1/Emulation/roms/switch",
     "executableArgs": "--fullscreen \"'${filePath}'\"",


### PR DESCRIPTION
Very important