### PR TITLE
Steam Rom Manager configuration for EasyRPG

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -4016,5 +4016,71 @@
     },
     "parserId": "164712598905497531",
     "version": 10
+  },
+  {
+    "parserType": "Glob",
+    "configTitle": "RPG Maker - Retroarch - EasyRPG",
+    "steamCategory": "${RPG Maker}",
+    "steamDirectory": "${steamdirglobal}",
+    "romDirectory": "${romsdirglobal}/easyrpg",
+    "executableArgs": "run org.libretro.RetroArch -L /easyrpg_libretro.so \"${filePath}\"",
+    "executableModifier": "\"${exePath}\"",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "imageProviders": [
+      "SteamGridDB"
+    ],
+    "onlineImageQueries": "${${title}}",
+    "imagePool": "${title}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "userAccounts": {
+      "specifiedAccounts": "",
+      "skipWithMissingDataDir": true,
+      "useCredentials": true
+    },
+    "executable": {
+      "path": "${retroarchpath}",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "parserInputs": {
+      "glob": "${title}/*@(.ldb|.easyrpg)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "imageProviderAPIs": {
+      "SteamGridDB": {
+        "nsfw": false,
+        "humor": false,
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": [],
+        "imageMotionTypes": [
+          "static"
+        ]
+      }
+    },
+    "parserId": "167174183584229566",
+    "version": 10,
+    "disabled": false
   }
 ]


### PR DESCRIPTION
Adds a predefined configuration for EasyRPG to the Steam Rom Manager.

Games must be placed in the `easyrpg` folder in the directory of the other roms. In an RPG Maker game, the executable is always called the same. Therefore, the folder name must be used as the title. The `title` and not the `fuzzyTitle` must also be used for the image query.