### PR TITLE
Steam Rom Manager configuration for PSX M3U compatible with EmulationStation-DE and no duplicate

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2911,6 +2911,72 @@
   },
   {
     "parserType": "Glob",
+    "configTitle": "Sony PlayStation - Retroarch - Beetle PSX HW (M3U)",
+    "steamCategory": "${PlayStation}",
+    "steamDirectory": "${steamdirglobal}",
+    "romDirectory": "${romsdirglobal}/psx",
+    "executableArgs": "run org.libretro.RetroArch -L /mednafen_psx_hw_libretro.so \"${filePath}\"",
+    "executableModifier": "\"${exePath}\"",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "imageProviders": [
+      "SteamGridDB"
+    ],
+    "onlineImageQueries": "${${fuzzyTitle}}",
+    "imagePool": "${fuzzyTitle}",
+    "defaultImage": "",
+    "defaultTallImage": "",
+    "defaultHeroImage": "",
+    "defaultLogoImage": "",
+    "defaultIcon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png",
+    "localImages": "",
+    "localTallImages": "",
+    "localHeroImages": "",
+    "localLogoImages": "",
+    "localIcons": "",
+    "userAccounts": {
+      "specifiedAccounts": "",
+      "skipWithMissingDataDir": true,
+      "useCredentials": true
+    },
+    "executable": {
+      "path": "${retroarchpath}",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "parserInputs": {
+      "glob": "*/${title}@(.m3u|.M3U)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "imageProviderAPIs": {
+      "SteamGridDB": {
+        "nsfw": false,
+        "humor": false,
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": [],
+        "imageMotionTypes": [
+          "static"
+        ]
+      }
+    },
+    "parserId": "167174069060034231",
+    "version": 10,
+    "disabled": true
+  },
+  {
+    "parserType": "Glob",
     "configTitle": "Sony PlayStation - Retroarch - SwanStation",
     "steamCategory": "${PlayStation - SwanStation}",
     "steamDirectory": "${steamdirglobal}",


### PR DESCRIPTION
There is a problem with the Steam Rom Manager configuration for PlayStation when using M3U. 

As described [here](https://gitlab.com/es-de/emulationstation-de/-/blob/master/USERGUIDE.md#multiple-game-files-installation) EmulationStation-DE needs a folder structure like this to work:

> Wild Arms 2 (USA).m3u
> - Wild Arms 2 (USA) (Disc 1).chd
> - Wild Arms 2 (USA) (Disc 2).chd
> - Wild Arms 2 (USA).m3u

But with the current configuration all three files and the folder are detected and added to Steam.  

<details>
  <summary>Parsing result</summary>

```
[172/179]:      Extracted title - Wild Arms 2 (USA)
[172/179]:          Fuzzy title - Wild Arms 2
[172/179]:          Final title - Wild Arms 2
[172/179]:            File path - /run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u
[172/179]:            Start dir - /usr/bin
[172/179]:    Complete shortcut - "/usr/bin/flatpak" run org.libretro.RetroArch -L /mednafen_psx_hw_libretro.so "/run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u"
[172/179]:     Steam categories - PlayStation - Beetle
[172/179]:        Image queries - Wild Arms 2
[172/179]:  Default icon glob:
[172/179]:                        /home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
[172/179]:       Default logo image:
[172/179]:                        file:////home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png

[173/179]:      Extracted title - Wild Arms 2 (USA) (Disc 1)
[173/179]:          Fuzzy title - Wild Arms 2
[173/179]:          Final title - Wild Arms 2
[173/179]:            File path - /run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA) (Disc 1).chd
[173/179]:            Start dir - /usr/bin
[173/179]:    Complete shortcut - "/usr/bin/flatpak" run org.libretro.RetroArch -L /mednafen_psx_hw_libretro.so "/run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA) (Disc 1).chd"
[173/179]:     Steam categories - PlayStation - Beetle
[173/179]:        Image queries - Wild Arms 2
[173/179]:  Default icon glob:
[173/179]:                        /home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
[173/179]:       Default logo image:
[173/179]:                        file:////home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png

[174/179]:      Extracted title - Wild Arms 2 (USA) (Disc 2)
[174/179]:          Fuzzy title - Wild Arms 2
[174/179]:          Final title - Wild Arms 2
[174/179]:            File path - /run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA) (Disc 2).chd
[174/179]:            Start dir - /usr/bin
[174/179]:    Complete shortcut - "/usr/bin/flatpak" run org.libretro.RetroArch -L /mednafen_psx_hw_libretro.so "/run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA) (Disc 2).chd"
[174/179]:     Steam categories - PlayStation - Beetle
[174/179]:        Image queries - Wild Arms 2
[174/179]:  Default icon glob:
[174/179]:                        /home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
[174/179]:       Default logo image:
[174/179]:                        file:////home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png

[175/179]:      Extracted title - Wild Arms 2 (USA)
[175/179]:          Fuzzy title - Wild Arms 2
[175/179]:          Final title - Wild Arms 2
[175/179]:            File path - /run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA).m3u
[175/179]:            Start dir - /usr/bin
[175/179]:    Complete shortcut - "/usr/bin/flatpak" run org.libretro.RetroArch -L /mednafen_psx_hw_libretro.so "/run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA).m3u"
[175/179]:     Steam categories - PlayStation - Beetle
[175/179]:        Image queries - Wild Arms 2
[175/179]:  Default icon glob:
[175/179]:                        /home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
[175/179]:       Default logo image:
[175/179]:                        file:////home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
```
</details>

In my opinion we need a separate M3U Steam Rom Manager configuration here. 

I've added `Sony PlayStation - Retroarch - Beetle PSX HW (M3U)` as an example for such configuration. With this separate configuration Steam Rom Manager only detects the M3U file and no duplicate appears.

<details>
  <summary>New parsing result</summary>

```
[52/53]:      Extracted title - Wild Arms 2 (USA)
[52/53]:          Fuzzy title - Wild Arms 2
[52/53]:          Final title - Wild Arms 2
[52/53]:            File path - /run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA).m3u
[52/53]:            Start dir - /usr/bin
[52/53]:    Complete shortcut - "/usr/bin/flatpak" run org.libretro.RetroArch -L /mednafen_psx_hw_libretro.so "/run/media/mmcblk0p1/Emulation/roms/psx/Wild Arms 2 (USA).m3u/Wild Arms 2 (USA).m3u"
[52/53]:     Steam categories - PlayStation
[52/53]:        Image queries - Wild Arms 2
[52/53]:  Default icon glob:
[52/53]:                        /home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
[52/53]:       Default logo image:
[52/53]:                        file:////home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png
```
</details>
