### PR TITLE
Fix DOSBox-pure config directory

### DIFF
--- a/functions/EmuScripts/emuDeckRetroArch.sh
+++ b/functions/EmuScripts/emuDeckRetroArch.sh
@@ -1600,7 +1600,7 @@ RetroArch_bsnes_hd_beta_setUpCoreOpt(){
 }
 
 RetroArch_dos_box_setUpCoreOpt(){
-	RetroArch_setOverride 'DOSBox-pure.opt' 'DOSBox Pure'  'dosbox_pure_conf' '"inside"'
+	RetroArch_setOverride 'DOSBox-pure.opt' 'DOSBox-pure'  'dosbox_pure_conf' '"inside"'
 }
 
 RetroArch_setUpCoreOptAll(){


### PR DESCRIPTION
The directory is `DOSBox-pure` and not `DOSBox Pure`

Fixes https://github.com/dragoonDorise/EmuDeck/issues/534