### PR TITLE
Use new decky installer location

### DIFF
--- a/functions/ToolScripts/emuDeckPlugins.sh
+++ b/functions/ToolScripts/emuDeckPlugins.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 Plugins_installPluginLoader(){
-   local PluginLoader_releaseURL="https://github.com/SteamDeckHomebrew/PluginLoader/raw/main/dist/install_release.sh"
+   local PluginLoader_releaseURL="https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh"
    mkdir -p "$HOME/homebrew"
    sudo chown -R deck:deck "$HOME/homebrew"
    curl -L $PluginLoader_releaseURL | sh


### PR DESCRIPTION
Decky's installer has moved so you'll need to point at the new location

To be clear, this isn't urgent so no rush