### PR TITLE
Fixed flatpak launchers update

### DIFF
--- a/functions/updateEmuFP.sh
+++ b/functions/updateEmuFP.sh
@@ -12,8 +12,8 @@ updateEmuFP(){
 	
 	shName=$(echo "$name" | awk '{print tolower($0)}')
 	
-	find "${toolsPath}"launchers/ -type f -iname $shName.sh | while read f; do echo "deleting $f"; rm -f "$f"; done;
-	cp "${EMUDECKGIT}"/tools/launchers/"${shName}".sh "${toolsPath}"launchers/"${shName}".sh
-	chmod +x "${toolsPath}"launchers/"${shName}".sh
+	find "${toolsPath}"/launchers/ -type f -iname $shName.sh | while read f; do echo "deleting $f"; rm -f "$f"; done;
+	cp "${EMUDECKGIT}"/tools/launchers/"${shName}".sh "${toolsPath}"/launchers/"${shName}".sh
+	chmod +x "${toolsPath}"/launchers/"${shName}".sh
 	
 }


### PR DESCRIPTION
Fixed flatpak launcher scripts update path (missing slash) - No such file or directory errors in log

On every flatpak update (tools & stuff, update emulators, update flatpaks) there are bunch of errors in the log and the launcher scripts are not updated. This should fix that.

```
[Sun Jan 15 02:25:04 AM CET 2023] stderr: find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/primehack.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/primehack.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/rpcs3.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/rpcs3.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/citra.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/citra.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/dolphin-emu.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/dolphin-emu.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/duckstation.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/duckstation.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/retroarch.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/retroarch.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/ppsspp.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/ppsspp.sh': No such file or directory
find: ‘/run/media/mmcblk0p1/Emulation/toolslaunchers/’: No such file or directory
cp: cannot create regular file '/run/media/mmcblk0p1/Emulation/toolslaunchers/xemu-emu.sh': No such file or directory
chmod: cannot access '/run/media/mmcblk0p1/Emulation/toolslaunchers/xemu-emu.sh': No such file or directory
```
