### PR TITLE
PS2 Parser, PC98 Parser, Wii Parser Changes

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2103,7 +2103,7 @@
       "useCredentials": true
     },
     "parserInputs": {
-      "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.m3u|.M3U)"
+      "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.m3u|.M3U|.json|.JSON)"
     },
     "titleFromVariable": {
       "limitToGroups": "",
@@ -3256,7 +3256,7 @@
   {
     "parserType": "Glob",
     "configTitle": "Sony PlayStation 2 - PCSX2",
-    "steamCategory": "${Playstation 2}",
+    "steamCategory": "${PlayStation 2}",
     "steamDirectory": "${steamdirglobal}",
     "romDirectory": "${romsdirglobal}/ps2",
     "executableArgs": "-batch -fullscreen \"'${filePath}'\"",
@@ -4217,11 +4217,11 @@
     "configTitle": "NEC - PC-98 - RetroArch",
     "steamCategory": "${NEC - PC-98}",
     "executableModifier": "\"${exePath}\"",
-    "romDirectory": "${romsdirglobal}/vic20",
+    "romDirectory": "${romsdirglobal}/pc98",
     "steamDirectory": "${steamdirglobal}",
     "startInDirectory": "",
     "titleModifier": "${fuzzyTitle}",
-    "executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_xvic_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+    "executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}np2kai_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
     "onlineImageQueries": "${${fuzzyTitle}}",
     "imagePool": "${fuzzyTitle}",
     "imageProviders": ["SteamGridDB"],


### PR DESCRIPTION
* PS2 Parser: `PlayStation 2` to `PlayStation 2`
* PC98 Parser: Updated ROM Directory and Libretro Core
* Wii Parser: Added `.json` and `.JSON` file types