### PR TITLE
Fixed Parsec & Remote Play Launchers

### DIFF
--- a/functions/RemotePlayClientScripts/remotePlayChiaki.sh
+++ b/functions/RemotePlayClientScripts/remotePlayChiaki.sh
@@ -14,8 +14,8 @@ Chiaki_install() {
 	flatpak install flathub "$ID" -y --user
 	flatpak override "$ID" --filesystem=host --user
 	flatpak override "$ID" --share=network --user
-	cp "${EMUDECKGIT}/tools/remoteplayclients/Chiaki Remote Play Clients.sh" "$romsPath/remoteplay"
-	chmod +x "$romsPath/remoteplay/Chiaki Remote Play Clients.sh"
+	cp "$EMUDECKGIT/tools/remoteplayclients/Chiaki Remote Play Client.sh" "$romsPath/remoteplay"
+	chmod +x "$romsPath/remoteplay/Chiaki Remote Play Client.sh"
 	Chiaki_addSteamInputProfile
 }
 
@@ -26,19 +26,23 @@ Chiaki_init() {
 	$Chiaki_addSteamInputProfile
 }
 
-# Update flatpak
+# Update flatpak & launcher script
 Chiaki_update() {
 	setMSG "Updating $Chiaki_emuName settings."
 	local ID="$Chiaki_emuPath"
 	flatpak update $ID -y --user	
 	flatpak override $ID --filesystem=host --user
-	flatpak override $ID --share=network --user	
+	flatpak override $ID --share=network --user
+	rm "$romsPath/remoteplay/Chiaki Remote Play Client.sh"
+	cp "$EMUDECKGIT/tools/remoteplayclients/Chiaki Remote Play Client.sh" "$romsPath/remoteplay"
+	chmod +x "$romsPath/remoteplay/Chiaki Remote Play Client.sh"
 }
 
 # Uninstall
 Chiaki_uninstall() {
 	setMSG "Uninstalling $Chiaki_emuName."
     uninstallEmuFP "$Chiaki_emuPath"
+	rm "$romsPath/remoteplay/Chiaki Remote Play Client.sh"
 }
 
 # Check if installed

--- a/functions/RemotePlayClientScripts/remotePlayMoonlight.sh
+++ b/functions/RemotePlayClientScripts/remotePlayMoonlight.sh
@@ -14,7 +14,7 @@ Moonlight_install() {
 	flatpak install flathub "$ID" -y --user
 	flatpak override "$ID" --filesystem=host --user
 	flatpak override "$ID" --share=network --user
-	cp "${EMUDECKGIT}/tools/remoteplayclients/Moonlight Game Streaming.sh" "$romsPath/remoteplay"
+	cp "$EMUDECKGIT/tools/remoteplayclients/Moonlight Game Streaming.sh" "$romsPath/remoteplay"
 	chmod +x "$romsPath/remoteplay/Moonlight Game Streaming.sh"
 	Moonlight_addSteamInputProfile
 }
@@ -26,19 +26,23 @@ Moonlight_init() {
 	$Moonlight_addSteamInputProfile
 }
 
-# Update flatpak
+# Update flatpak & launcher script
 Moonlight_update() {
 	setMSG "Updating $Moonlight_emuName settings."
 	local ID="$Moonlight_emuPath"
 	flatpak update $ID -y --user	
 	flatpak override $ID --filesystem=host --user
-	flatpak override $ID --share=network --user	
+	flatpak override $ID --share=network --user
+	rm "$romsPath/remoteplay/Moonlight Game Streaming.sh"
+	cp "$EMUDECKGIT/tools/remoteplayclients/Moonlight Game Streaming.sh" "$romsPath/remoteplay"
+	chmod +x "$romsPath/remoteplay/Moonlight Game Streaming.sh"
 }
 
 # Uninstall
 Moonlight_uninstall() {
 	setMSG "Uninstalling $Moonlight_emuName."
     uninstallEmuFP "$Moonlight_emuPath"
+	rm "$romsPath/remoteplay/Moonlight Game Streaming.sh"
 }
 
 # Check if installed

--- a/functions/RemotePlayClientScripts/remotePlayParsec.sh
+++ b/functions/RemotePlayClientScripts/remotePlayParsec.sh
@@ -14,7 +14,7 @@ Parsec_install() {
 	flatpak install flathub "$ID" -y --user
 	flatpak override "$ID" --filesystem=host --user
 	flatpak override "$ID" --share=network --user
-	cp "${EMUDECKGIT}/tools/remoteplayclients/Parsec.sh" "$romsPath/remoteplay"
+	cp "$EMUDECKGIT/tools/remoteplayclients/Parsec.sh" "$romsPath/remoteplay"
 	chmod +x "$romsPath/remoteplay/Parsec.sh"
 	Parsec_addSteamInputProfile
 }
@@ -26,19 +26,23 @@ Parsec_init() {
 	$Parsec_addSteamInputProfile
 }
 
-# Update flatpak
+# Update flatpak & launcher script
 Parsec_update() {
 	setMSG "Updating $Parsec_emuName settings."
 	local ID="$Parsec_emuPath"
 	flatpak update $ID -y --user	
 	flatpak override $ID --filesystem=host --user
-	flatpak override $ID --share=network --user	
+	flatpak override $ID --share=network --user
+	rm "$romsPath/remoteplay/Parsec.sh"
+	cp "$EMUDECKGIT/tools/remoteplayclients/Parsec.sh" "$romsPath/remoteplay"
+	chmod +x "$romsPath/remoteplay/Parsec.sh"
 }
 
 # Uninstall
 Parsec_uninstall() {
 	setMSG "Uninstalling $Parsec_emuName."
     uninstallEmuFP "$Parsec_emuPath"
+	rm "$romsPath/remoteplay/Parsec.sh"
 }
 
 # Check if installed

--- a/functions/all.sh
+++ b/functions/all.sh
@@ -19,6 +19,7 @@ chmod +x "${EMUDECKGIT}/tools/binaries/xmlstarlet"
 
 source "$EMUDECKGIT"/functions/checkBIOS.sh
 source "$EMUDECKGIT"/functions/checkInstalledEmus.sh
+#source "$EMUDECKGIT"/functions/cloudServicesManager.sh
 source "$EMUDECKGIT"/functions/configEmuAI.sh
 source "$EMUDECKGIT"/functions/configEmuFP.sh
 source "$EMUDECKGIT"/functions/createDesktopIcons.sh

--- a/tools/remoteplayclients/Parsec.sh
+++ b/tools/remoteplayclients/Parsec.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+cd ~/.local/share/flatpak/app/com.parsecgaming.parsec/current/active/files/bin
 /usr/bin/flatpak run com.parsecgaming.parsec


### PR DESCRIPTION
Fixed Parsec & Remote Play Launchers

- Fixed Parsec crashing when opening from Steam
- Added update/repair of remote play client launchers
- Added `CloudScripts_update` function to cloudServicesManager.sh for externally updating scripts
- Fixed typos