### PR TITLE
RPCS3 FSR and optimizations

### DIFF
--- a/configs/net.rpcs3.RPCS3/config/rpcs3/config.yml
+++ b/configs/net.rpcs3.RPCS3/config/rpcs3/config.yml
@@ -18,7 +18,7 @@ Core:
   SPU delay penalty: 3
   SPU loop detection: false
   Max SPURS Threads: 6
-  SPU Block Size: Safe
+  SPU Block Size: Mega
   Accurate GETLLAR: false
   Accurate SPU DMA: false
   Accurate Cache Line Stores: false
@@ -74,7 +74,7 @@ Video:
   Read Color Buffers: false
   Read Depth Buffer: false
   Log shader programs: false
-  VSync: false
+  VSync: true
   Debug output: false
   Debug overlay: false
   Renderdoc Compatibility Mode: false
@@ -92,7 +92,7 @@ Video:
   Use full RGB output range: true
   Strict Texture Flushing: false
   Disable native float16 support: false
-  Multithreaded RSX: false
+  Multithreaded RSX: true
   Relaxed ZCULL Sync: false
   Enable 3D: false
   Debug Program Analyser: false
@@ -112,13 +112,14 @@ Video:
   Allow Host GPU Labels: false
   Disable MSL Fast Math: false
   Software VkSemaphore: false
+  Output Scaling Mode: FidelityFX Super Resolution
   Vulkan:
     Adapter: AMD RADV VANGOGH
     Force FIFO present mode: false
     Force primitive restart flag: false
     Force Disable Exclusive Fullscreen Mode: false
     Asynchronous Texture Streaming 2: false
-    Enable FidelityFX Super Resolution Upscaling: false
+    Enable FidelityFX Super Resolution Upscaling: true
     FidelityFX CAS Sharpening Intensity: 50
     Asynchronous Queue Scheduler: Safe
   Performance Overlay:

--- a/configs/net.rpcs3.RPCS3/config/rpcs3/config.yml
+++ b/configs/net.rpcs3.RPCS3/config/rpcs3/config.yml
@@ -18,7 +18,7 @@ Core:
   SPU delay penalty: 3
   SPU loop detection: false
   Max SPURS Threads: 6
-  SPU Block Size: Mega
+  SPU Block Size: Safe
   Accurate GETLLAR: false
   Accurate SPU DMA: false
   Accurate Cache Line Stores: false
@@ -92,7 +92,7 @@ Video:
   Use full RGB output range: true
   Strict Texture Flushing: false
   Disable native float16 support: false
-  Multithreaded RSX: true
+  Multithreaded RSX: false
   Relaxed ZCULL Sync: false
   Enable 3D: false
   Debug Program Analyser: false


### PR DESCRIPTION
Testing a few config options to hopefully improve performance with RPCS3 on the deck.

All of this needs extensive testing besides probably Vsync and FSR enabled (won't do anything currently).

- Use FSR for output scaling
  - Ideally downscale resolution to match to 75% or 50% to reduce load on CPU as a benefit
- Multithreaded RSX
- Vsync On
- SPU Blocksize Mega

Possible further optimizations:
- ZCULL Accuracy -> Approx/Relaxed
- Shader Mode -> Async with Shader Interpreter
- SPU Blocksize -> Giga
- Shader Quality -> Auto
- CPU XFloat Accuracy -> Relaxed
- Resolution Scale -> 50%/75%

Reference: https://wiki.rpcs3.net/index.php?title=Help:Default_Settings