### PR TITLE
SRM - Add "app" file type to Standalone MelonDS

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2151,7 +2151,7 @@
       "useCredentials": true
     },
     "parserInputs": {
-      "glob": "**/${title}@(.nds|.NDS)"
+      "glob": "**/${title}@(.nds|.NDS|.app|.APP)"
     },
     "titleFromVariable": {
       "limitToGroups": "",


### PR DESCRIPTION
For DSIware emulation

Requires external DSI BIOS and switching the `Console Type` to `DSI` in MelonDS.