### PR TITLE
merge the two ps3 + edit ps2 steam cat for consistency

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -2974,7 +2974,7 @@
   {
     "parserType": "Glob",
     "configTitle": "Sony PlayStation 2 - PCSX2",
-    "steamCategory": "${Playstation 2}",
+    "steamCategory": "${PlayStation 2}",
     "steamDirectory": "${steamdirglobal}",
     "romDirectory": "${romsdirglobal}/ps2",
     "executableArgs": "-batch -fullscreen -bigpicture \"'${filePath}'\"",
@@ -3097,7 +3097,7 @@
   {
     "parserType": "Glob",
     "configTitle": "Sony PlayStation 3 - RPCS3(Flatpak) (Installed PKG)",
-    "steamCategory": "${PS3}",
+    "steamCategory": "${PlayStation 3}",
     "steamDirectory": "${steamdirglobal}",
     "romDirectory": "/run/media/mmcblk0p1/Emulation/storage/rpcs3/dev_hdd0/game",
     "executableArgs": "run net.rpcs3.RPCS3 --no-gui \"${filePath}\"",


### PR DESCRIPTION
Always found it weird why one ps3 was "PlayStation 3" and the other being "PS3" in Steam, this PR make them the same category, also fixed the capitalization of the ps2 category