### PR TITLE
Added a check to Remote Play Clients

### DIFF
--- a/functions/RemotePlayClientScripts/remotePlayChiaki.sh
+++ b/functions/RemotePlayClientScripts/remotePlayChiaki.sh
@@ -48,6 +48,12 @@ Chiaki_uninstall() {
 # Check if installed
 Chiaki_IsInstalled() {
 	if [ "$(flatpak --columns=app list | grep "$Chiaki_emuPath")" == "$Chiaki_emuPath" ]; then
+		# Uninstall if previously installed to the "system" level
+		flatpak list | grep "$Chiaki_emuPath" | grep "system"
+		if [ $? == 0 ]; then
+			Chiaki_uninstall
+			Chiaki_install
+		fi
 		echo true
 		return 1
 	else

--- a/functions/RemotePlayClientScripts/remotePlayChiaki.sh
+++ b/functions/RemotePlayClientScripts/remotePlayChiaki.sh
@@ -16,7 +16,7 @@ Chiaki_install() {
 	flatpak override "$ID" --share=network --user
 	cp "$EMUDECKGIT/tools/remoteplayclients/Chiaki Remote Play Client.sh" "$romsPath/remoteplay"
 	chmod +x "$romsPath/remoteplay/Chiaki Remote Play Client.sh"
-	Chiaki_addSteamInputProfile
+	#Chiaki_addSteamInputProfile
 }
 
 # ApplyInitialSettings

--- a/functions/RemotePlayClientScripts/remotePlayMoonlight.sh
+++ b/functions/RemotePlayClientScripts/remotePlayMoonlight.sh
@@ -16,7 +16,7 @@ Moonlight_install() {
 	flatpak override "$ID" --share=network --user
 	cp "$EMUDECKGIT/tools/remoteplayclients/Moonlight Game Streaming.sh" "$romsPath/remoteplay"
 	chmod +x "$romsPath/remoteplay/Moonlight Game Streaming.sh"
-	Moonlight_addSteamInputProfile
+	#Moonlight_addSteamInputProfile
 }
 
 # ApplyInitialSettings

--- a/functions/RemotePlayClientScripts/remotePlayMoonlight.sh
+++ b/functions/RemotePlayClientScripts/remotePlayMoonlight.sh
@@ -48,6 +48,12 @@ Moonlight_uninstall() {
 # Check if installed
 Moonlight_IsInstalled() {
 	if [ "$(flatpak --columns=app list | grep "$Moonlight_emuPath")" == "$Moonlight_emuPath" ]; then
+		# Uninstall if previously installed to the "system" level
+		flatpak list | grep "$Moonlight_emuPath" | grep "system"
+		if [ $? == 0 ]; then
+			Moonlight_uninstall
+			Moonlight_install
+		fi
 		echo true
 		return 1
 	else

--- a/functions/RemotePlayClientScripts/remotePlayParsec.sh
+++ b/functions/RemotePlayClientScripts/remotePlayParsec.sh
@@ -16,7 +16,7 @@ Parsec_install() {
 	flatpak override "$ID" --share=network --user
 	cp "$EMUDECKGIT/tools/remoteplayclients/Parsec.sh" "$romsPath/remoteplay"
 	chmod +x "$romsPath/remoteplay/Parsec.sh"
-	Parsec_addSteamInputProfile
+	#Parsec_addSteamInputProfile
 }
 
 # ApplyInitialSettings

--- a/functions/RemotePlayClientScripts/remotePlayParsec.sh
+++ b/functions/RemotePlayClientScripts/remotePlayParsec.sh
@@ -48,6 +48,12 @@ Parsec_uninstall() {
 # Check if installed
 Parsec_IsInstalled() {
 	if [ "$(flatpak --columns=app list | grep "$Parsec_emuPath")" == "$Parsec_emuPath" ]; then
+		# Uninstall if previously installed to the "system" level
+		flatpak list | grep "$Parsec_emuPath" | grep "system"
+		if [ $? == 0 ]; then
+			Parsec_uninstall
+			Parsec_install
+		fi
 		echo true
 		return 1
 	else


### PR DESCRIPTION
Fixes issue #713 "Parsec Gaming Mode shortcut not launching with new EmuDeck Update"

- Ensures that the remote play clients are installed to the "user" level and not the "system" level

## For end users to implement this change:

- You need to launch "Cloud Services Manager" then go to the "Remote Play Clients" menu. Upon entering the menu, the fix will be applied if necessary.