### PR TITLE
Added Nebula as a Cloud Service

### DIFF
--- a/tools/cloud/Nebula.sh
+++ b/tools/cloud/Nebula.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+LINK="https://nebula.tv/"
+
+source ./cloud.conf
+"/usr/bin/flatpak" run ${FLATPAKOPTIONS} ${BROWSERAPP} @@u @@ ${BROWSEROPTIONS} ${LINK}


### PR DESCRIPTION
This PR should add [Nebula](https://nebula.tv/) as a Cloud Service. 

However, I'm not sure if this works, as there isn't much documentation (that I could find) on how to add new cloud services.

Additionally, [this](https://github.com/dragoonDorise/EmuDeck/wiki/cloud-services) wiki page would need to be updated, but I'm unsure how to do that with a PR.

Apologies for not using the dev branch to make this PR, but it hasn't yet been updated to have cloud service support, so I couldn't work with it. 

Since I haven't tested this to see if it works, I'm open to adding any additional code that might be necessary to make it functional. Currently, this serves more as a suggestion than a final PR.
