### PR TITLE
helperFunctions - getReleaseURLGH / getLatestReleaseURLGH

### DIFF
--- a/functions/helperFunctions.sh
+++ b/functions/helperFunctions.sh
@@ -371,31 +371,34 @@ function checkForFile(){
 	done
 }
 
-function getLatestReleaseURLGH(){	
-    local repository=$1
-    local fileType=$2
-	local url	
-	#local token=$(tokenGenerator)
-
-    if [ "$url" == "" ]; then
-        url="https://api.github.com/repos/${repository}/releases/latest"
-    fi
-
-    url="$(curl -sL $url | jq -r ".assets[].browser_download_url" | grep -ve 'i386' | grep .${fileType}\$)"
-    echo "$url"
-}
-
-function getReleaseURLGH(){	
-    local repository=$1
-    local fileType=$2
+function getLatestReleaseURLGH(){
+	local repository=$1
+	local fileType=$2
+	local fileNameContains=$3
 	local url
 	#local token=$(tokenGenerator)
 
-    if [ "$url" == "" ]; then
-        url="https://api.github.com/repos/$repository/releases"
-    fi
-    curl -fSs "$url" | \
-    jq -r '[ .[].assets[] | select(.name | endswith("'"$fileType"'")).browser_download_url ][0]'
+	if [ "$url" == "" ]; then
+		url="https://api.github.com/repos/${repository}/releases/latest"
+	fi
+
+	curl -u -fSs "$url" | \
+		jq -r '[ .assets[] | select(.name | contains("'"$fileNameContains"'") and endswith("'"$fileType"'")).browser_download_url ][0] // empty'
+}
+
+function getReleaseURLGH(){
+	local repository=$1
+	local fileType=$2
+	local url
+	local fileNameContains=$3
+	#local token=$(tokenGenerator)
+
+	if [ "$url" == "" ]; then
+		url="https://api.github.com/repos/$repository/releases"
+	fi
+
+	curl -fSs "$url" | \
+		jq -r '[ .[].assets[] | select(.name | contains("'"$fileNameContains"'") and endswith("'"$fileType"'")).browser_download_url ][0] // empty'
 }
 
 function linkToSaveFolder(){	

--- a/tools/savesync.sh
+++ b/tools/savesync.sh
@@ -6,21 +6,6 @@ SAVESYNC_systemd_path="$HOME/.config/systemd/user"
 
 source "$HOME/.config/EmuDeck/backend/functions/all.sh"
 
-function getReleaseURLGH(){	
-	local repository=$1
-	local fileType=$2
-	local url
-	#local token=$(tokenGenerator)
-
-	if [ "$url" == "" ]; then
-		url="https://api.github.com/repos/$repository/releases"
-	fi
-	curl -fSs "$url" | \
-	jq -r '[ .[].assets[] | select(.name | endswith("'"$fileType"'")).browser_download_url ][0]'
-	
-}
-
-
 SAVESYNC_install(){	
 	
 	text="`printf " <b>Have your login details ready!</b>\n\nA new browser windows will open for your cloud provider.\nMake sure you have your cretendials ready because you only have <b>20 seconds to enter them</b>. \n\n you can always reconfigure SaveSync in the future )"`"


### PR DESCRIPTION
Added "contains" argument, allows for more granular filtering of GitHub releases
No changes if no argument or empty argument is supplied
Removed duplicated getReleasURLGH() from savesync.sh (it sources all.sh)

Notes: 
- I am playing with Ryujinx Avalonia builds and although the changes above do not appear used yet, it comes in handy at least for that (getting -ava builds).
- The helperFunctions.sh file tabs/spaces indentation is a mess. I opted to use tabs for these changes but should probably be unified throughout whole file.
