### PR TITLE
Hotfix: adds updating the roms path in usersettings to the migration

### DIFF
--- a/functions/ToolScripts/emuDeckMigration.sh
+++ b/functions/ToolScripts/emuDeckMigration.sh
@@ -106,6 +106,10 @@ Migration_updateSRM(){
 	origin=$1
 	destination=$2		
 	find "$HOME/.local/share/Steam/userdata" -name "shortcuts.vdf" -exec sed -i "s|${origin}|${destination}|g" {} +
+	tmp=$(mktemp)
+	jq -r --arg ROMSDIR "$romsPath" '.environmentVariables.romsDirectory = "\($ROMSDIR)"' \
+	"$HOME/.config/steam-rom-manager/userData/userSettings.json" > "$tmp" \
+	&& mv "$tmp" "$HOME/.config/steam-rom-manager/userData/userSettings.json"
 }
 
 Migration_updateParsers(){


### PR DESCRIPTION
This should make it so that when a user uses the migration tool, they don't have to reset the config for SRM after.