### PR TITLE
 Use a more consistent naming style for SRM parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,59 @@ If you wanna help us improve EmuDeck we are open to accept your PR! Just keep in
 - Things using sudo are a big no no, there are exceptions but always try to find a way of prevent using sudo.
 - Every Emulator added has to be included on this readme file, have a SRM profile and follow the AmberElec hotkey mapping ( just check the previous table)
 - Always do your PR to the dev branch.
+
+## Submitting a PR Request for a Steam ROM Manager Parser
+
+If you would like to submit a PR request for a Steam ROM Manager parser, use the following format:
+
+### The Basics
+
+* Spell out console names - no acronyms
+    * For example, `PSP` should be spelled out as `PlayStation Portable`
+* Respect original capitalization and spacing 
+    * A few examples:
+        * `RetroArch` uses a capital `R` and capital `A`
+        * The `Nintendo Game Boy` uses a capital `N`, `G`, and `B` with spaces between each word
+        * The `PlayStation Portable` uses a capital `P` and `S` in `PlayStation` as do the other `PlayStation` handhelds and consoles
+
+### Parser Structure
+
+* `configTitle`: 
+    * `COMPANYNAME SYSTEMNAME - EMULATORNAME RETROARCHCORENAME`
+        * If the standalone emulator name is identical to the RetroArch core name, add `(Standalone)` behind the `EMULATORNAME`
+    * A few examples:
+        * Config Title: `"configTitle": "Amiga - RetroArch PUAE",` 
+        * Config Title: `"configTitle": "Nintendo Game Boy Color - mGBA (Standalone)",`
+        * Config Title: `"configTitle": "Sony PlayStation 2 - PCSX2",`
+* `steamCategory`:
+    * **Note:** Non-Default Parsers refer to when a system has multiple emulation choices (through alternative emulators or RetroArch cores). Only one of these parsers is enabled by default and any alternative choices are disabled by default.  
+    * Default Parsers:
+        * `COMPANYNAME CONSOLENAME`
+    * Non-Default Parsers:
+        * Standalone: `COMPANYNAME CONSOLENAME - EMULATORNAME`
+        * RetroArch Core: `COMPANYNAME CONSOLENAME - RETROARCHCORENAME`
+            * If the RetroArch core's name is identical to the Standalone emulator name, add `RetroArch` in front of the `RETROARCHCORENAME`
+            * If the standalone emulator name is identical to the RetroArch core name, add `(Standalone)` behind the `EMULATORNAME`
+    * A few examples: 
+        * Default Parsers:  
+            * Mupen64Plus Next (RetroArch core for Nintendo 64)
+                * Steam Category Name: `"steamCategory": ""${Nintendo 64}",`
+            * DuckStation  (PSX Emulator)
+                * Steam Category Name: `"steamCategory": "${Sony PlayStation}",`
+        * Non-Default Parsers:
+            * Rosalie's Mupen GUI (N64 Emulator) 
+                * Steam Category Name: `"steamCategory": "${Nintendo 64 - Rosalie's Mupen GUI}",`
+            * Beetle PSX HW (RetroArch core for PSX)
+                * Steam Category Name: `"steamCategory": "${Sony PlayStation - Beetle PSX HW}",`
+
+### Parser Filename
+
+`companyname_systemname-emulatorname-retroarchcore.json`
+
+If it is a RetroArch core, replace `emulatorname` with `ra`.
+
+* A few examples:
+    * `nintendo_wii-dolphin.json`
+    * `nintendo_64-rmg.json`
+    * `nintendo_gba-ra-mgba.json`
+    * `sega_saturn-ra-mednafen.json`

--- a/configs/steam-rom-manager/userData/parsers/emudeck/amiga-ra-puae.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/amiga-ra-puae.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Amiga - Retroarch",
+  "configTitle": "Amiga - RetroArch PUAE",
   "steamCategory": "${Amiga}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/amiga",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/amiga_1200-ra-puae.json.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/amiga_1200-ra-puae.json.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Amiga 1200 - Retroarch",
+  "configTitle": "Amiga 1200 - RetroArch PUAE",
   "steamCategory": "${Amiga 1200}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/amiga1200",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/amiga_600-ra-puae.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/amiga_600-ra-puae.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Amiga 600 - Retroarch",
+  "configTitle": "Amiga 600 - RetroArch PUAE",
   "steamCategory": "${Amiga 600}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/amiga600",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/amiga_cd-ra-puae.json.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/amiga_cd-ra-puae.json.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Amiga CD - Retroarch",
+  "configTitle": "Amiga CD - RetroArch PUAE",
   "steamCategory": "${Amiga CD}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/amigacd32",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/amstrad_cpc-ra-cap32.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/amstrad_cpc-ra-cap32.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Amstrad CPC - RetroArch - Caprice32",
+  "configTitle": "Amstrad CPC - RetroArch Caprice32",
   "steamCategory": "${Amstrad CPC}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/amstradcpc",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade-mame.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade-mame.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Arcade - MAME (standalone)",
+  "configTitle": "Arcade - MAME (Standalone)",
   "steamCategory": "${Arcade}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/arcade",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-fbneo.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-fbneo.json
@@ -1,16 +1,16 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Arcade - RetroArch FBNeo",
+  "steamCategory": "${Arcade - FBNeo}",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fbneo_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/fbneo",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
+  "imageProviders": ["SteamGridDB"],
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -22,31 +22,31 @@
   "localLogoImages": "",
   "localIcons": "",
   "disabled": false,
+  "executable": {
+    "path": "${retroarchpath}",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": true
+  },
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(7z|7Z|.zip|.ZIP)"
   },
   "titleFromVariable": {
-    "limitToGroups": "",
+    "limitToGroups": "${MAME}",
     "caseInsensitiveVariables": false,
     "skipFileIfVariableWasNotFound": false,
-    "tryToMatchTitle": false
+    "tryToMatchTitle": true
   },
   "fuzzyMatch": {
     "replaceDiacritics": true,
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
+  "parserId": "164824416516097457",
   "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-mame.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-mame.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Arcade - RetroArch MAME Current",
-  "steamCategory": "${Arcade MAME Current}",
+  "steamCategory": "${Arcade - MAME Current}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/arcade",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-mame_2003_plus.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-mame_2003_plus.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Arcade - RetroArch MAME 2003 Plus",
-  "steamCategory": "${Arcade MAME 2003+}",
+  "steamCategory": "${Arcade - MAME 2003 Plus}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/mame",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-mame_2010.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade-ra-mame_2010.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Arcade - RetroArch MAME 2010",
-  "steamCategory": "${Arcade MAME 2010}",
+  "steamCategory": "${Arcade - MAME 2010}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/mame2010",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi-ra-flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi-ra-flycast.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Arcade - Naomi",
+  "configTitle": "Arcade - Naomi - RetroArch Flycast",
   "steamCategory": "${Arcade - Naomi}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/naomi",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/atari_2600-ra-stella.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/atari_2600-ra-stella.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Atari 2600 - Retroarch - Stella",
+  "configTitle": "Atari 2600 - RetroArch Stella",
   "steamCategory": "${Atari 2600}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/atari2600",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/atari_lynx-ra-mednafen.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/atari_lynx-ra-mednafen.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Atari Lynx - RetroArch Beetle Handy",
+  "steamCategory": "${Atari Lynx}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/atarilynx",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_lynx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -28,7 +28,7 @@
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.7z|.7Z|.lnx|.LNX|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -44,9 +44,9 @@
   "executable": {
     "path": "${retroarchpath}",
     "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
+    "appendArgsToExecutable": true
   },
-  "parserId": "164785621902122396",
+  "parserId": "164785590686474494",
   "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {

--- a/configs/steam-rom-manager/userData/parsers/emudeck/bandai_wonderswan-ra-mednafen_swan.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/bandai_wonderswan-ra-mednafen_swan.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Bandai WonderSwan - Retroarch Beetle Cygne",
-  "steamCategory": "${WonderSwan}",
+  "configTitle": "Bandai WonderSwan - RetroArch Beetle Cygne",
+  "steamCategory": "${Bandai WonderSwan}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wonderswan",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/bandai_wonderswan_color-ra-mednafen_swan.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/bandai_wonderswan_color-ra-mednafen_swan.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Bandai WonderSwan Color - Retroarch Beetle Cygne",
-  "steamCategory": "${WonderSwan}",
+  "configTitle": "Bandai WonderSwan Color - RetroArch Beetle Cygne",
+  "steamCategory": "${Bandai WonderSwan Color}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wonderswancolor",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/commodore_16-ra-vice_xplus4.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/commodore_16-ra-vice_xplus4.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Commodore 16 - Retroarch",
+  "configTitle": "Commodore 16 - RetroArch VICE",
   "steamCategory": "${Commodore 16}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/c16",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/commodore_64-ra-vice_x64.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/commodore_64-ra-vice_x64.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Commodore 64 - Retroarch",
+  "configTitle": "Commodore 64 - RetroArch VICE",
   "steamCategory": "${Commodore 64}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/c64",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/commodore_vic_20-ra-vice_xvic.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/commodore_vic_20-ra-vice_xvic.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Commodore Vic-20 - RetroArch",
-  "steamCategory": "${Commodore Vic-20}",
+  "configTitle": "Commodore VIC-20 - RetroArch VICE",
+  "steamCategory": "${Commodore VIC-20}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/vic20",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/doom-ra-prboom.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/doom-ra-prboom.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "DooM - Retroarch - PrBoom",
+  "configTitle": "DooM - RetroArch PrBoom",
   "steamCategory": "${DooM}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/doom",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/dos-ra-dosbox_pure.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/dos-ra-dosbox_pure.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "DOS - Retroarch(Flatpak) - DOSBox Pure",
+  "configTitle": "DOS - RetroArch DOSBox Pure",
   "steamCategory": "${DOS}",
   "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}dosbox_pure_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/microsoft_xbox-xemu.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/microsoft_xbox-xemu.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Microsoft XBox - Xemu",
-  "steamCategory": "${XBox}",
+  "configTitle": "Microsoft Xbox - Xemu",
+  "steamCategory": "${Microsoft Xbox}",
   "executableArgs": " -full-screen -dvd_path \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/xbox",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/microsoft_xbox_360-xenia-xbla.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/microsoft_xbox_360-xenia-xbla.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Microsoft Xbox 360 - Xenia - XBLA",
-  "steamCategory": "${Xbox 360}",
+  "configTitle": "Microsoft Xbox 360 - Xbox Live Arcade - Xenia",
+  "steamCategory": "${Microsoft Xbox 360 - Xbox Live Arcade}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/xbox360/roms/",
   "executableArgs": "\"Z:${filePath}\"",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/microsoft_xbox_360-xenia.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/microsoft_xbox_360-xenia.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Microsoft Xbox 360 - Xenia",
-  "steamCategory": "${Xbox 360}",
+  "steamCategory": "${Microsoft Xbox 360}",
   "executableArgs": "\"Z:${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/xbox360/",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nec_pc_98-ra-np2kai.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nec_pc_98-ra-np2kai.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "NEC - PC-98 - RetroArch",
-  "steamCategory": "${NEC - PC-98}",
+  "configTitle": "NEC PC-98 - RetroArch NP2kai",
+  "steamCategory": "${NEC PC-98}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/pc98",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nec_pc_engine_turbografx_16-ra-beetle_pce.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nec_pc_engine_turbografx_16-ra-beetle_pce.json
@@ -1,16 +1,16 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "configTitle": "NEC PC Engine/TurboGrafx 16 - RetroArch Beetle PCE",
+  "steamCategory": "${NEC PC Engine/TurboGrafx 16}",
   "steamDirectory": "${steamdirglobal}",
+  "romDirectory": "${romsdirglobal}",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pce_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "imageProviders": ["SteamGridDB"],
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -21,14 +21,18 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
+  "executable": {
+    "path": "${retroarchpath}",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": true
+  },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "@(pcengine|tg16)/**/${title}@(.7z|.7Z|.bin|.BIN|.pce|.PCE|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -41,22 +45,17 @@
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
-  "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,
       "humor": false,
-      "imageMotionTypes": ["static"],
       "styles": [],
       "stylesHero": [],
       "stylesLogo": [],
-      "stylesIcon": []
+      "stylesIcon": [],
+      "imageMotionTypes": ["static"]
     }
-  }
+  },
+  "parserId": "165855998563219386",
+  "version": 10
 }

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nec_pc_engine_turbografx_16_cd-ra-beetle_pce.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nec_pc_engine_turbografx_16_cd-ra-beetle_pce.json
@@ -1,16 +1,16 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "configTitle": "NEC PC Engine/TurboGrafx 16 CD - RetroArch Beetle PCE",
+  "steamCategory": "${NEC PC Engine/TurboGrafx 16 CD}",
   "steamDirectory": "${steamdirglobal}",
+  "romDirectory": "${romsdirglobal}",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pce_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "imageProviders": ["SteamGridDB"],
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -21,14 +21,18 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
+  "executable": {
+    "path": "${retroarchpath}",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": true
+  },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "@(pcenginecd|tg-cd)/**/${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -41,22 +45,17 @@
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
-  "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,
       "humor": false,
-      "imageMotionTypes": ["static"],
       "styles": [],
       "stylesHero": [],
       "stylesLogo": [],
-      "stylesIcon": []
+      "stylesIcon": [],
+      "imageMotionTypes": ["static"]
     }
-  }
+  },
+  "parserId": "165856080826916450",
+  "version": 10
 }

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_64-ra-mupen64plus_next.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_64-ra-mupen64plus_next.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo 64 - Retroarch - Mupen64Plus Next",
+  "configTitle": "Nintendo 64 - RetroArch Mupen64Plus Next",
   "steamCategory": "${Nintendo 64}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/n64",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_64-rmg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_64-rmg.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo 64 - RMG",
-  "steamCategory": "${Nintendo 64 - RMG}",
+  "configTitle": "Nintendo 64 - Rosalie's Mupen GUI",
+  "steamCategory": "${Nintendo 64 - Rosalie's Mupen GUI}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}",
   "executableArgs": "--fullscreen --nogui --quit-after-emulation \"${filePath}\"",
@@ -21,6 +21,7 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
+  "disabled": true,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_ds-melonds.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_ds-melonds.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo DS - melonDS",
-  "steamCategory": "${Nintendo DS - melonDS Standalone}",
+  "configTitle": "Nintendo DS - melonDS (Standalone)",
+  "steamCategory": "${Nintendo DS - melonDS (Standalone)}",
   "executableArgs": "run net.kuribo64.melonDS \"${filePath}\" -f",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/nds",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_ds-ra-melonds.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_ds-ra-melonds.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo DS - Retroarch - melonDS",
+  "configTitle": "Nintendo DS - RetroArch melonDS",
   "steamCategory": "${Nintendo DS}",
   "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}melonds_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gb-mGBA.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gb-mGBA.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy - mGBA",
-  "steamCategory": "${GameBoy - mGBA}",
+  "configTitle": "Nintendo Game Boy - mGBA (Standalone)",
+  "steamCategory": "${Nintendo Game Boy - mGBA (Standalone)}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gb-ra-gambatte.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gb-ra-gambatte.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy - Retroarch - Gambatte",
-  "steamCategory": "${GameBoy}",
+  "configTitle": "Nintendo Game Boy - RetroArch Gambatte",
+  "steamCategory": "${Nintendo Game Boy}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gb-ra-sameboy.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gb-ra-sameboy.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy - Retroarch - Sameboy",
-  "steamCategory": "${GameBoy}",
+  "configTitle": "Nintendo Game Boy - RetroArch SameBoy",
+  "steamCategory": "${Nintendo Game Boy - SameBoy}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gba-mGBA.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gba-mGBA.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy Advance - mGBA (Standalone)",
-  "steamCategory": "${GameBoy Advance - mGBA}",
+  "configTitle": "Nintendo Game Boy Advance - mGBA (Standalone)",
+  "steamCategory": "${Nintendo Game Boy Advance - mGBA (Standalone)}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gba-ra-mgba.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gba-ra-mgba.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy Advance - Retroarch - mGBA",
-  "steamCategory": "${GameBoy Advance}",
+  "configTitle": "Nintendo Game Boy Advance - RetroArch mGBA",
+  "steamCategory": "${Nintendo Game Boy Advance}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gbc-mgba.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gbc-mgba.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Nintendo Game Boy Color - mGBA (Standalone)",
+  "steamCategory": "${Nintendo Game Boy Color - mGBA (Standalone)}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "-f \"'${filePath}'\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -21,14 +21,14 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
+  "disabled": true,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -42,12 +42,26 @@
     "removeBrackets": true
   },
   "executable": {
-    "path": "${retroarchpath}",
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
     "shortcutPassthrough": false,
     "appendArgsToExecutable": false
   },
-  "parserId": "164785621902122396",
-  "version": 10,
+  "parserId": "164785621855061661",
+  "version": 13,
+  "controllers": {
+    "ps4": null,
+    "ps5": null,
+    "xbox360": null,
+    "xboxone": null,
+    "switch_joycon_left": null,
+    "switch_joycon_right": null,
+    "switch_pro": null,
+    "neptune": {
+      "title": "EmuDeck - mGBA",
+      "mappingId": "mGBA_controller_config.vdf",
+      "profileType": "template"
+    }
+  },
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gbc-ra-gambatte.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gbc-ra-gambatte.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy Color - Retroarch - Gambatte",
-  "steamCategory": "${GameBoy Color}",
+  "configTitle": "Nintendo Game Boy Color - RetroArch Gambatte",
+  "steamCategory": "${Nintendo Game Boy Color}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gbc-ra-sameboy.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gbc-ra-sameboy.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo GameBoy Color - Retroarch SameBoy",
+  "configTitle": "Nintendo Game Boy Color - RetroArch SameBoy",
   "steamCategory": "${Nintendo Game Boy Color - SameBoy}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gc-dolphin.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gc-dolphin.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Nintendo GameCube - Dolphin",
-  "steamCategory": "${Gamecube}",
+  "steamCategory": "${Nintendo GameCube}",
   "executableArgs": "vblank_mode=0 %command% run org.DolphinEmu.dolphin-emu -b -e \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/gamecube",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_nes-ra-mesen.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_nes-ra-mesen.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo NES - Retroarch - Mesen",
-  "steamCategory": "${NES}",
+  "configTitle": "Nintendo Entertainment System - RetroArch Mesen",
+  "steamCategory": "${Nintendo Entertainment System}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_primehack.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_primehack.json
@@ -1,16 +1,16 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "configTitle": "Nintendo Metroid Prime Trilogy - PrimeHack",
+  "steamCategory": "${Nintendo Wii}",
   "steamDirectory": "${steamdirglobal}",
+  "romDirectory": "${romsdirglobal}/primehacks",
+  "executableArgs": "vblank_mode=0 %command% run io.github.shiiion.primehack -b -e \"${filePath}\"",
+  "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "imageProviders": ["SteamGridDB"],
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -21,14 +21,18 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
+  "executable": {
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/primehack.sh",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": false
+  },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.json|.JSON|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.WBFS)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -41,22 +45,17 @@
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
-  "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,
       "humor": false,
-      "imageMotionTypes": ["static"],
       "styles": [],
       "stylesHero": [],
       "stylesLogo": [],
-      "stylesIcon": []
+      "stylesIcon": [],
+      "imageMotionTypes": ["static"]
     }
-  }
+  },
+  "parserId": "164770728884890305",
+  "version": 10
 }

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_snes-ra-bsnes_hd.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_snes-ra-bsnes_hd.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo SNES WideScreen - Retroarch - Snes9x",
-  "steamCategory": "${Super Nintendo WideScreen}",
+  "configTitle": "Nintendo SNES (Super Nintendo) HD - RetroArch bsnes-hd",
+  "steamCategory": "${Nintendo SNES (Super Nintendo) HD - bsnes-hd}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/sneshd",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_snes-ra-snes9x.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_snes-ra-snes9x.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo SNES - Retroarch - Snes9x",
-  "steamCategory": "${Super Nintendo}",
+  "configTitle": "Nintendo SNES (Super Nintendo) - RetroArch Snes9x",
+  "steamCategory": "${Nintendo SNES (Super Nintendo)}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_switch-ryujinx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_switch-ryujinx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Nintendo Switch - Ryujinx",
-  "steamCategory": "${Switch - Ryujinx}",
+  "steamCategory": "${Nintendo Switch - Ryujinx}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/switch",
   "executableArgs": "--fullscreen \"'${filePath}'\"",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wii-dolphin.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wii-dolphin.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Nintendo Wii - Dolphin",
-  "steamCategory": "${Wii}",
+  "steamCategory": "${Nintendo Wii}",
   "executableArgs": "vblank_mode=0 %command% run org.DolphinEmu.dolphin-emu -b -e \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wii",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-native-rpx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-native-rpx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo WiiU - Cemu (.rpx) - Native",
-  "steamCategory": "${WiiU}",
+  "configTitle": "Nintendo Wii U - Cemu Native (.rpx)",
+  "steamCategory": "${Nintendo Wii U - Cemu Native}",
   "executableArgs": "vblank_mode=0 %command% -f -g \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wiiu/roms/",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-native-wud-wux-wua.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-native-wud-wux-wua.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo WiiU - Cemu (.wud, .wux, .wua) - Native",
-  "steamCategory": "${WiiU}",
+  "configTitle": "Nintendo Wii U - Cemu Native (.wud, .wux, .wua)",
+  "steamCategory": "${Nintendo Wii U - Cemu Native}",
   "executableArgs": "vblank_mode=0 %command% -f -g \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wiiu/roms/",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-proton-rpx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-proton-rpx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo WiiU - Cemu (.rpx) - Proton",
-  "steamCategory": "${WiiU - Proton}",
+  "configTitle": "Nintendo Wii U - Cemu Proton (.rpx)",
+  "steamCategory": "${Nintendo Wii U - Cemu Proton}",
   "executableArgs": "vblank_mode=0 %command% -w -f -g \"Z:${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wiiu/roms/",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-proton-wud-wux-wua.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wiiu-cemu-proton-wud-wux-wua.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Nintendo WiiU - Cemu (.wud, .wux, .wua) - Proton",
-  "steamCategory": "${WiiU - Proton}",
+  "configTitle": "Nintendo Wii U - Cemu Proton (.wud, .wux, .wua)",
+  "steamCategory": "${Nintendo Wii U - Cemu Proton}",
   "executableArgs": "vblank_mode=0 %command% -w -f -g \"Z:${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wiiu/roms/",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/panasonic_3do-ra-opera.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/panasonic_3do-ra-opera.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Panasonic 3DO",
-  "steamCategory": "${3DO}",
+  "configTitle": "Panasonic 3DO - RetroArch Opera",
+  "steamCategory": "${Panasonic 3DO}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/3do",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/philips_cd_i-ra-same_cdi.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/philips_cd_i-ra-same_cdi.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Philips CD-i - RetroArch",
+  "configTitle": "Philips CD-i - RetroArch SAME CDi",
   "steamCategory": "${Philips CD-i}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/cdimono1",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/rpg_maker-ra-easyrpg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/rpg_maker-ra-easyrpg.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "RPG Maker - Retroarch - EasyRPG",
+  "configTitle": "RPG Maker - RetroArch EasyRPG",
   "steamCategory": "${RPG Maker}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/easyrpg",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/scumm_scummvm.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/scumm_scummvm.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "ScummVM - Standalone",
+  "configTitle": "ScummVM (Standalone)",
   "steamCategory": "${ScummVM}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/scummvm",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_32X-ra-picodrive.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_32X-ra-picodrive.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega 32X - Retroarch - PicoDrive",
+  "configTitle": "Sega 32X - RetroArch PicoDrive",
   "steamCategory": "${Sega 32X}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/sega32x",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_CD_Mega_CD-ra-genesis_plus_gx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_CD_Mega_CD-ra-genesis_plus_gx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega CD/Mega CD - Retroarch - Genesis Plus GX",
-  "steamCategory": "${Sega CD}",
+  "configTitle": "Sega CD/Mega CD - RetroArch Genesis Plus GX",
+  "steamCategory": "${Sega CD/Mega CD}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_dreamcast-Flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_dreamcast-Flycast.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
   "configTitle": "Sega Dreamcast - Flycast (Standalone)",
-  "steamCategory": "${Dreamcast}",
+  "steamCategory": "${Sega Dreamcast (Standalone)}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/dreamcast",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_dreamcast-ra-flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_dreamcast-ra-flycast.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Dreamcast - Retroarch - Flycast",
+  "configTitle": "Sega Dreamcast - RetroArch Flycast",
   "steamCategory": "${Sega Dreamcast}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/dreamcast",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_game_gear-ra-genesis_plus_gx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_game_gear-ra-genesis_plus_gx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Game Gear - Retroarch - Genesis Plus GX",
-  "steamCategory": "${Game Gear}",
+  "configTitle": "Sega Game Gear - RetroArch Genesis Plus GX",
+  "steamCategory": "${Sega Game Gear}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_genesis-ra-genesis_plus_gx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_genesis-ra-genesis_plus_gx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Genesis/Mega Drive - Retroarch - Genesis Plus GX",
-  "steamCategory": "${Genesis/Mega Drive}",
+  "configTitle": "Sega Genesis/Mega Drive - RetroArch Genesis Plus GX",
+  "steamCategory": "${Sega Genesis/Mega Drive}",
   "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_genesis-ra-genesis_plus_gx_wide.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_genesis-ra-genesis_plus_gx_wide.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Genesis/Mega Drive WideScreen - Retroarch - Genesis Plus GX",
-  "steamCategory": "${Genesis WideScreen}",
+  "configTitle": "Sega Genesis/Mega Drive WideScreen - RetroArch Genesis Plus GX",
+  "steamCategory": "${Sega Genesis/Mega Drive WideScreen}",
   "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_wide_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/genesiswide",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_mastersystem-ra-genesis-plus-gx.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_mastersystem-ra-genesis-plus-gx.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Master System - Retroarch - Genesis Plus GX",
-  "steamCategory": "${Master System}",
+  "configTitle": "Sega Master System - RetroArch Genesis Plus GX",
+  "steamCategory": "${Sega Master System}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_saturn-ra-mednafen.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_saturn-ra-mednafen.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Saturn - RetroArch - Beetle",
-  "steamCategory": "${Saturn}",
+  "configTitle": "Sega Saturn - RetroArch Beetle",
+  "steamCategory": "${Sega Saturn}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/saturn",
   "executableArgs": "-L /mednafen_saturn_libretro.so \"${filePath}\"",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_saturn-ra-yabause.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_saturn-ra-yabause.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sega Saturn - Retroarch - Yabause",
-  "steamCategory": "${Saturn}",
+  "configTitle": "Sega Saturn - RetroArch Yabause",
+  "steamCategory": "${Sega Saturn - Yabause}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/saturn",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sharp-x68000-ra-px68k.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sharp-x68000-ra-px68k.json
@@ -1,6 +1,6 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sharp X68000 - RetroArch",
+  "configTitle": "Sharp X68000 - RetroArch PX68k",
   "steamCategory": "${Sharp X68000}",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/x68000",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sinclair_zx-spectrum-ra-fuse.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sinclair_zx-spectrum-ra-fuse.json
@@ -1,16 +1,16 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "configTitle": "Sinclair ZX Spectrum - RetroArch Fuse",
+  "steamCategory": "${Sinclair ZX Spectrum}",
   "steamDirectory": "${steamdirglobal}",
+  "romDirectory": "${romsdirglobal}/zxspectrum",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fuse_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "imageProviders": ["SteamGridDB"],
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -21,14 +21,18 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
+  "executable": {
+    "path": "${retroarchpath}",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": true
+  },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.7z|.tzx|.tap|.z80|.rzx|.scl|.trd|.TZX|.TAP|.Z80|.RZX|.SCL|.TRD|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -41,22 +45,18 @@
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
-  "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,
       "humor": false,
-      "imageMotionTypes": ["static"],
       "styles": [],
       "stylesHero": [],
       "stylesLogo": [],
-      "stylesIcon": []
+      "stylesIcon": [],
+      "imageMotionTypes": ["static"]
     }
-  }
+  },
+  "parserId": "164785583010740300",
+  "version": 10,
+  "disabled": false
 }

--- a/configs/steam-rom-manager/userData/parsers/emudeck/snk_neo_geo_pocket-ra-beetle_neopop.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/snk_neo_geo_pocket-ra-beetle_neopop.json
@@ -1,9 +1,9 @@
 {
   "parserType": "Glob",
-  "configTitle": "SNK Neo Geo Pocket/Color - Retroarch - Beetle NeoPop",
-  "steamCategory": "${Neo Geo Pocket}",
+  "configTitle": "SNK Neo Geo Pocket - RetroArch Beetle NeoPop",
+  "steamCategory": "${SNK Neo Geo Pocket}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/ngpc",
+  "romDirectory": "${romsdirglobal}/ngp",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/snk_neo_geo_pocket_color-ra-beetle_neopop.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/snk_neo_geo_pocket_color-ra-beetle_neopop.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "SNK Neo Geo Pocket Color - RetroArch Beetle NeoPop",
+  "steamCategory": "${SNK Neo Geo Pocket Color}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/ngpc",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_ngp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -28,7 +28,7 @@
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.7z|.7Z|.ngc|.NGC|.ngp|.NGP|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -44,9 +44,9 @@
   "executable": {
     "path": "${retroarchpath}",
     "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
+    "appendArgsToExecutable": true
   },
-  "parserId": "164785621902122396",
+  "parserId": "164785621885441701",
   "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps2-pcsx2.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps2-pcsx2.json
@@ -1,16 +1,16 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "configTitle": "Sony PlayStation 2 - PCSX2",
+  "steamCategory": "${Sony PlayStation 2}",
   "steamDirectory": "${steamdirglobal}",
+  "romDirectory": "${romsdirglobal}/ps2",
+  "executableArgs": "-batch -fullscreen \"'${filePath}'\"",
+  "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "imageProviders": ["SteamGridDB"],
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -21,14 +21,18 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
+  "executable": {
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/pcsx2-qt.sh",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": false
+  },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.bin|.BIN|.chd|.CHD|.cso|.CSO|.dump|.DUMP|.gz|.GZ|.img|.IMG|.iso|.ISO|.mdf|.MDF|.nrg|.NRG)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -41,22 +45,17 @@
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
-  "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,
       "humor": false,
-      "imageMotionTypes": ["static"],
       "styles": [],
       "stylesHero": [],
       "stylesLogo": [],
-      "stylesIcon": []
+      "stylesIcon": [],
+      "imageMotionTypes": ["static"]
     }
-  }
+  },
+  "parserId": "164785208872922785",
+  "version": 10
 }

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-extracted_iso_psn.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-extracted_iso_psn.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Sony PlayStation 3 - RPCS3 (Extracted ISO/PSN)",
+  "steamCategory": "${Sony PlayStation 3}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/ps3",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "--no-gui \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -28,13 +28,13 @@
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}/PS3_GAME/USRDIR/@(eboot.bin|EBOOT.BIN|ISO.BIN.EDAT|iso.bin.edat)"
   },
   "titleFromVariable": {
-    "limitToGroups": "",
+    "limitToGroups": "${PS3}",
     "caseInsensitiveVariables": false,
     "skipFileIfVariableWasNotFound": false,
-    "tryToMatchTitle": false
+    "tryToMatchTitle": true
   },
   "fuzzyMatch": {
     "replaceDiacritics": true,
@@ -42,11 +42,11 @@
     "removeBrackets": true
   },
   "executable": {
-    "path": "${retroarchpath}",
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh",
     "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
+    "appendArgsToExecutable": true
   },
-  "parserId": "164785621902122396",
+  "parserId": "164785645271669680",
   "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-pkg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-pkg.json
@@ -1,16 +1,16 @@
 {
-  "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "parserType": "Glob-regex",
+  "configTitle": "Sony PlayStation 3 - RPCS3 (Installed PKG)",
+  "steamCategory": "${Sony PlayStation 3}",
   "steamDirectory": "${steamdirglobal}",
+  "romDirectory": "/run/media/mmcblk0p1/Emulation/storage/rpcs3/dev_hdd0/game",
+  "executableArgs": "--no-gui \"${filePath}\"",
+  "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "imageProviders": ["SteamGridDB"],
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
   "defaultImage": "",
   "defaultTallImage": "",
   "defaultHeroImage": "",
@@ -21,32 +21,31 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
+  "executable": {
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh",
+    "shortcutPassthrough": false,
+    "appendArgsToExecutable": true
+  },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob-regex": "${/(^[NP].+)/}/USRDIR/@(eboot.bin|EBOOT.BIN)"
   },
   "titleFromVariable": {
-    "limitToGroups": "",
+    "limitToGroups": "${PS3}",
     "caseInsensitiveVariables": false,
     "skipFileIfVariableWasNotFound": false,
-    "tryToMatchTitle": false
+    "tryToMatchTitle": true
   },
   "fuzzyMatch": {
     "replaceDiacritics": true,
     "removeCharacters": true,
     "removeBrackets": true
   },
-  "executable": {
-    "path": "${retroarchpath}",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
-  },
-  "parserId": "164785621902122396",
+  "parserId": "165182011334544893",
   "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psp-ppsspp.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psp-ppsspp.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Sony PlayStation Portable - PPSSPP (Standalone)",
+  "steamCategory": "${Sony PlayStation Portable}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/psp",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "-f -g \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -28,7 +28,7 @@
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.7z|.7Z|.elf|.ELF|.cso|.CSO|.iso|.ISO|.pbp|.PBP|.prx|.PRX)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -42,12 +42,26 @@
     "removeBrackets": true
   },
   "executable": {
-    "path": "${retroarchpath}",
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/ppsspp.sh",
     "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
+    "appendArgsToExecutable": true
   },
-  "parserId": "164785621902122396",
-  "version": 10,
+  "parserId": "164785656634747068",
+  "version": 13,
+  "controllers": {
+    "ps4": null,
+    "ps5": null,
+    "xbox360": null,
+    "xboxone": null,
+    "switch_joycon_left": null,
+    "switch_joycon_right": null,
+    "switch_pro": null,
+    "neptune": {
+      "title": "EmuDeck - PPSSPP Standalone",
+      "mappingId": "ppsspp_controller_config.vdf",
+      "profileType": "template"
+    }
+  },
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psp-ra-ppsspp.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psp-ra-ppsspp.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Sony PlayStation Portable - RetroArch PPSSPP",
+  "steamCategory": "${Sony PlayStation Portable - RetroArch PPSSPP}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/psp",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}ppsspp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -21,14 +21,14 @@
   "localHeroImages": "",
   "localLogoImages": "",
   "localIcons": "",
-  "disabled": false,
+  "disabled": true,
   "userAccounts": {
     "specifiedAccounts": "",
     "skipWithMissingDataDir": true,
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.7z|.7Z|.elf|.ELF|.cso|.CSO|.iso|.ISO|.pbp|.PBP|.prx|.PRX)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -44,9 +44,9 @@
   "executable": {
     "path": "${retroarchpath}",
     "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
+    "appendArgsToExecutable": true
   },
-  "parserId": "164785621902122396",
+  "parserId": "164785656684747068",
   "version": 10,
   "imageProviderAPIs": {
     "SteamGridDB": {

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psvita-vita3k-pkg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psvita-vita3k-pkg.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sony PlayStation Vita Installed PKG - Vita3k",
-  "steamCategory": "${PlayStation Vita}",
+  "configTitle": "Sony PlayStation Vita - Vita3k (Installed PKG)",
+  "steamCategory": "${Sony PlayStation Vita}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}${/}psvita",
   "executableArgs": "-Fr \"${/.*[/\\\\]([^/\\\\]+)[/\\\\]/|${filePath}}\"",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psx-duckstation.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psx-duckstation.json
@@ -1,13 +1,13 @@
 {
   "parserType": "Glob",
-  "configTitle": "Pico 8 - RetroArch Retro8",
-  "steamCategory": "${Pico 8}",
+  "configTitle": "Sony PlayStation - DuckStation (Standalone)",
+  "steamCategory": "${Sony PlayStation}",
   "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/pico8",
+  "romDirectory": "${romsdirglobal}/psx",
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+  "executableArgs": "-batch -fullscreen \"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -28,7 +28,7 @@
     "useCredentials": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+    "glob": "**/${title}@(.cue|.CUE|.img|.IMG|.chd|.CHD|.ecm|.ECM|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP)"
   },
   "titleFromVariable": {
     "limitToGroups": "",
@@ -42,12 +42,26 @@
     "removeBrackets": true
   },
   "executable": {
-    "path": "${retroarchpath}",
+    "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/duckstation.sh",
     "shortcutPassthrough": false,
-    "appendArgsToExecutable": false
+    "appendArgsToExecutable": true
   },
-  "parserId": "164785621902122396",
-  "version": 10,
+  "parserId": "164785656699856393",
+  "version": 13,
+  "controllers": {
+    "ps4": null,
+    "ps5": null,
+    "xbox360": null,
+    "xboxone": null,
+    "switch_joycon_left": null,
+    "switch_joycon_right": null,
+    "switch_pro": null,
+    "neptune": {
+      "title": "EmuDeck - DuckStation",
+      "mappingId": "duckstation_controller_config.vdf",
+      "profileType": "template"
+    }
+  },
   "imageProviderAPIs": {
     "SteamGridDB": {
       "nsfw": false,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psx-ra-beetle_psx_hw.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psx-ra-beetle_psx_hw.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sony PlayStation - Retroarch - Beetle PSX HW",
-  "steamCategory": "${PlayStation - Beetle}",
+  "configTitle": "Sony PlayStation - RetroArch Beetle PSX HW",
+  "steamCategory": "${Sony PlayStation - Beetle PSX HW}",
   "executableArgs": "-L /mednafen_psx_hw_libretro.so \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/psx",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psx-ra-swanstation.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psx-ra-swanstation.json
@@ -1,7 +1,7 @@
 {
   "parserType": "Glob",
-  "configTitle": "Sony PlayStation - Retroarch - SwanStation",
-  "steamCategory": "${PlayStation - SwanStation}",
+  "configTitle": "Sony PlayStation - RetroArch SwanStation",
+  "steamCategory": "${Sony PlayStation - SwanStation}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "${romsdirglobal}/psx",
   "executableArgs": "-L /swanstation_libretro.so \"${filePath}\"",


### PR DESCRIPTION
 Updated configTitle and steamCategory to be more consistent across parsers. One goal was to keep consoles together using their company name in Steam. 

Uses the following format:

**Config Title**

* `COMPANYNAME SYSTEMNAME - EMULATORNAME RETROARCHCORENAME`
* Includes `(Standalone)` at the end if EmuDeck includes a matching RetroArch core

**Steam Category Title**

Default Parsers:

* `COMPANYNAME CONSOLENAME`
    * Spelled out - limit acronyms for the most part (PSP --> spelled out as PlayStation Portable)

Non-Default Parsers:

* `COMPANYNAME CONSOLENAME - EMULATORNAME/CORENAME`
    * Spelled out - limit acronyms for the most part (PSP --> spelled out as PlayStation Portable)
    * If the RetroArch core's name is identical to the Standalone emulator name, `RetroArch` is included in front of the `CORENAME`
     * If the standalone emulator name is identical to the RetroArch core name, `(Standalone)` is included behind the `EMULATORNAME`

A few examples:

**Steam Category Name**

*  Microsoft Xbox 360 XBLA: 
    * Old Steam Category Name: `"steamCategory": "${Xbox 360}",`
    * New Steam Category Name: `"steamCategory": "${Microsoft Xbox 360 - Xbox Live Arcade}",`
* Nintendo SNES
    * Old Steam Category Name: `"steamCategory": "${Super Nintendo}",`
    * New Steam Category Name: `"steamCategory": "${Nintendo SNES (Super Nintendo)}",`
    * This is just a very clunky acronym to deal with so I copied the format from ES-DE. 
* PC Engine: 
    * Old Steam Category Name: `"steamCategory": "${PCE}",`
    * New Steam Category Name: `"steamCategory": "${NEC PC Engine/TurboGrafx 16",`
* PlayStation Portable
    * Old Steam Category Name: `"steamCategory": "${PSP}",`
    * New Steam Category Name: `"steamCategory": "${Sony PlayStation Portable - RetroArch PPSSPP}",`
    * Includes `RetroArch` because the PPSSPP core name is identical to the Standalone emulator name
* PrimeHack:
    * Old Steam Category Name: `"steamCategory": "${PrimeHack}",`
    * New Steam Category Name: `"steamCategory": "${Nintendo Wii}",`
    * Moves PrimeHack into the Wii category. EmuDeck "officially" only configures the Wii version so it's only one game. This keeps it together with the other Wii games instead of having a category for just Metroid Prime Trilogy.  
*  PSX - DuckStation:
    * Old Steam Category Name: `"steamCategory": "${PlayStation}",`
    * New Steam Category Name: `"steamCategory": "${Sony PlayStation}",`
* ZX Spectrum:
    * Old Steam Category Name: `"steamCategory": "${ZX Spectrum}",` 
    * New Steam Category Name: `"steamCategory": "${Sinclair ZX Spectrum}",`