### PR TITLE
Hotfix Dolphin and Flycast Parsers

### DIFF
--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gc-dolphin.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_gc-dolphin.json
@@ -2,7 +2,7 @@
   "parserType": "Glob",
   "configTitle": "Nintendo GameCube - Dolphin",
   "steamCategory": "${Nintendo GameCube}",
-  "executableArgs": "vblank_mode=0 %command% run org.DolphinEmu.dolphin-emu -b -e \"${filePath}\"",
+  "executableArgs": "vblank_mode=0 %command% -b -e \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/gamecube",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wii-dolphin.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/nintendo_wii-dolphin.json
@@ -2,7 +2,7 @@
   "parserType": "Glob",
   "configTitle": "Nintendo Wii - Dolphin",
   "steamCategory": "${Nintendo Wii}",
-  "executableArgs": "vblank_mode=0 %command% run org.DolphinEmu.dolphin-emu -b -e \"${filePath}\"",
+  "executableArgs": "vblank_mode=0 %command% -b -e \"${filePath}\"",
   "executableModifier": "\"${exePath}\"",
   "romDirectory": "${romsdirglobal}/wii",
   "steamDirectory": "${steamdirglobal}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sega_dreamcast-Flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sega_dreamcast-Flycast.json
@@ -1,62 +1,80 @@
-{
-  "parserType": "Glob",
-  "configTitle": "Sega Dreamcast - Flycast (Standalone)",
-  "steamCategory": "${Sega Dreamcast (Standalone)}",
-  "executableModifier": "\"${exePath}\"",
-  "romDirectory": "${romsdirglobal}/dreamcast",
-  "steamDirectory": "${steamdirglobal}",
-  "startInDirectory": "",
-  "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "run org.flycast.Flycast \"${filePath}\"",
-  "onlineImageQueries": "${${fuzzyTitle}}",
-  "imagePool": "${fuzzyTitle}",
-  "imageProviders": ["SteamGridDB"],
-  "defaultImage": "",
-  "defaultTallImage": "",
-  "defaultHeroImage": "",
-  "defaultLogoImage": "",
-  "defaultIcon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png",
-  "localImages": "",
-  "localTallImages": "",
-  "localHeroImages": "",
-  "localLogoImages": "",
-  "localIcons": "",
-  "disabled": false,
-  "userAccounts": {
-    "specifiedAccounts": "",
-    "skipWithMissingDataDir": true,
-    "useCredentials": true
-  },
-  "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI|.m3u|.M3U)"
-  },
-  "titleFromVariable": {
-    "limitToGroups": "",
-    "caseInsensitiveVariables": false,
-    "skipFileIfVariableWasNotFound": false,
-    "tryToMatchTitle": false
-  },
-  "fuzzyMatch": {
-    "replaceDiacritics": true,
-    "removeCharacters": true,
-    "removeBrackets": true
-  },
-  "executable": {
-    "path": "/usr/bin/flatpak",
-    "shortcutPassthrough": false,
-    "appendArgsToExecutable": true
-  },
-  "parserId": "164785622173694321",
-  "version": 2,
-  "imageProviderAPIs": {
-    "SteamGridDB": {
-      "nsfw": false,
-      "humor": false,
-      "imageMotionTypes": ["static"],
-      "styles": [],
-      "stylesHero": [],
-      "stylesLogo": [],
-      "stylesIcon": []
-    }
+  {
+      "parserType": "Glob",
+      "configTitle": "Sega Dreamcast - Flycast (Standalone)",
+      "steamDirectory": "${steamdirglobal}",
+      "steamCategory": "${Sega Dreamcast - Flycast (Standalone)}",
+      "romDirectory": "${romsdirglobal}/dreamcast",
+      "executableArgs": "\"${filePath}\"",
+      "executableModifier": "\"${exePath}\"",
+      "startInDirectory": "",
+      "titleModifier": "${fuzzyTitle}",
+      "fetchControllerTemplatesButton": null,
+      "removeControllersButton": null,
+      "imageProviders": [
+          "SteamGridDB"
+      ],
+      "onlineImageQueries": "${${fuzzyTitle}}",
+      "imagePool": "${fuzzyTitle}",
+      "userAccounts": {
+          "specifiedAccounts": ""
+      },
+      "executable": {
+          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
+          "shortcutPassthrough": false,
+          "appendArgsToExecutable": false
+      },
+      "parserInputs": {
+          "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI)"
+      },
+      "titleFromVariable": {
+          "limitToGroups": "",
+          "caseInsensitiveVariables": false,
+          "skipFileIfVariableWasNotFound": false,
+          "tryToMatchTitle": false
+      },
+      "fuzzyMatch": {
+          "replaceDiacritics": true,
+          "removeCharacters": true,
+          "removeBrackets": true
+      },
+      "controllers": {
+          "ps4": null,
+          "ps5": null,
+          "xbox360": null,
+          "xboxone": null,
+          "switch_joycon_left": null,
+          "switch_joycon_right": null,
+          "switch_pro": null,
+          "neptune": null
+      },
+      "imageProviderAPIs": {
+          "SteamGridDB": {
+              "nsfw": false,
+              "humor": false,
+              "styles": [],
+              "stylesHero": [],
+              "stylesLogo": [],
+              "stylesIcon": [],
+              "imageMotionTypes": [
+                  "static"
+              ]
+          }
+      },
+      "defaultImage": {
+          "tall": "",
+          "long": "",
+          "hero": "",
+          "logo": "",
+          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+      },
+      "localImages": {
+          "tall": "",
+          "long": "",
+          "hero": "",
+          "logo": "",
+          "icon": ""
+      },
+      "parserId": "164785622173694321",
+      "version": 15,
+      "disabled": true
   }
-}

--- a/tools/launchers/flycast.sh
+++ b/tools/launchers/flycast.sh
@@ -1,13 +1,5 @@
-#!/usr/bin/bash
-
-# shellcheck disable=SC1091
-. "${HOME}/emudeck/settings.sh"
-
-# shellcheck disable=SC2154
-LAUNCH="${toolsPath}/emu-launch.sh"
-
-# Set emulator name
-EMU="Flycast"
-
-# Launch emu-launch.sh
-"${LAUNCH}" -e "${EMU}" -- "${@}"
+#!/bin/sh
+source $HOME/.config/EmuDeck/backend/functions/all.sh
+cloud_sync_downloadEmu flycast
+/usr/bin/flatpak run org.flycast.Flycast "${@}"
+cloud_sync_uploadEmu flycast


### PR DESCRIPTION
* Fixed Flycast executable line (was causing errors)
* Removed M3U from Flycast parser (standalone does not support M3U apparently)
* Updated Flycast launcher script to add cloud support
* Removed redundant "launch Dolphin" line from Dolphin parsers