### PR TITLE
Update RPCS3 migration

### DIFF
--- a/tools/binupdate/binupdate.sh
+++ b/tools/binupdate/binupdate.sh
@@ -188,7 +188,7 @@ function runBinDownloads {
             messages+=("There was a problem updating Xenia")
         fi
     fi
-    if [[ "$binsToDL" == *"RPCS3"* ]]; then
+    if [[ "$binsToDL" == *"rpcs3"* ]]; then
         ((progresspct += pct)) || true
         echo "$progresspct"
         echo "# Updating RPCS3"
@@ -244,6 +244,9 @@ if [ "$(Vita3K_IsInstalled)" == "true" ]; then
 fi
 if [ "$(Xenia_IsInstalled)" == "true" ]; then
     binTable+=(TRUE "Xbox 360 Emu" "xenia")
+fi
+if [ "$(RPCS3_IsInstalled)" == "true" ]; then
+    binTable+=(TRUE "PlayStation 3 Emu" "rpcs3")
 fi
 
 if [ "${#binTable[@]}" -gt 0 ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -255,8 +255,13 @@ if [ "$doUninstall" == true ]; then
 		rm -rf $HOME/.var/app/com.github.Rosalie241.RMG &>> /dev/null
 	fi
 	if [[ "$doUninstallRPCS3" == true ]]; then
+		# Flatpak
 		flatpak uninstall net.rpcs3.RPCS3 -y
 		rm -rf $HOME/.var/app/net.rpcs3.RPCS3 &>> /dev/null
+		# AppImage
+		rm -rf "$HOME/.config/rpcs3" &>> /dev/null
+		rm -rf "$HOME/.cache/rpcs3" &>> /dev/null
+		rm -rf $HOME/.local/share/applications/RPCS3.desktop &>> /dev/null
 	fi
 	if [[ "$doUninstallRyujinx" == true ]]; then		
 		rm -rf $HOME/.config/Ryujinx &>> /dev/null


### PR DESCRIPTION
Continuing discussion from https://github.com/dragoonDorise/EmuDeck/pull/784#issuecomment-1701575741  

Makes sense to me to do this. 

I'm not sure how migration will be exposed in the UI though since the last migration with Yuzu was still using the cli version of EmuDeck. Or is adding the migration function to these two sections enough on its own?

@SilentException @dragoonDorise

Thank you SilentException! 