### PR TITLE
InstallEmuAI/InstallEmuBI Tweaks

### DIFF
--- a/functions/EmuScripts/emuDeckCemuNative.sh
+++ b/functions/EmuScripts/emuDeckCemuNative.sh
@@ -195,7 +195,7 @@ CemuNative_functions () {
 	install () {
 		echo "Begin Cemu - Native Install"
 		local showProgress="$1"
-		if installEmuAI "Cemu" "$(getReleaseURLGH "cemu-project/Cemu" ".AppImage")" "" "$showProgress"; then # Cemu.AppImage
+		if installEmuAI "${CemuNative[emuName]}" "$(getReleaseURLGH "cemu-project/Cemu" ".AppImage")" "" "$showProgress"; then # Cemu.AppImage
 			:
 		else
 			return 1

--- a/functions/EmuScripts/emuDeckMGBA.sh
+++ b/functions/EmuScripts/emuDeckMGBA.sh
@@ -14,7 +14,7 @@ mGBA_cleanup(){
 mGBA_install(){
 	echo "Begin mGBA Install"
 	local showProgress="$1"
-	if installEmuAI "mGBA" "$(getReleaseURLGH "mgba-emu/mgba" "x64.appimage")" "" "$showProgress"; then #mgba.AppImage
+	if installEmuAI "$mGBA_emuName" "$(getReleaseURLGH "mgba-emu/mgba" "x64.appimage")" "" "$showProgress"; then #mGBA.AppImage
 		:
 	else
 		return 1

--- a/functions/EmuScripts/emuDeckPCSX2QT.sh
+++ b/functions/EmuScripts/emuDeckPCSX2QT.sh
@@ -15,9 +15,9 @@ PCSX2QT_install() {
 	echo "Begin PCSX2-QT Install"
 	local showProgress="$1"
 	
-	if installEmuAI "pcsx2-Qt" "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4749/pcsx2-v1.7.4749-linux-appimage-x64-Qt.AppImage" "" "$showProgress"; then #pcsx2-Qt.AppImage	
-	#if installEmuAI "pcsx2-Qt" "$(getReleaseURLGH "PCSX2/pcsx2" "Qt.AppImage")" "" "$showProgress"; then #pcsx2-Qt.AppImage
-		:
+	if installEmuAI "${PCSX2QT_emuName}" "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4749/pcsx2-v1.7.4749-linux-appimage-x64-Qt.AppImage" "pcsx2-Qt" "$showProgress"; then #pcsx2-Qt.AppImage	
+	#if installEmuAI "${PCSX2QT_emuName}" "$(getReleaseURLGH "PCSX2/pcsx2" "Qt.AppImage")" "pcsx2-Qt" "$showProgress"; then #pcsx2-Qt.AppImage
+		rm -rf $HOME/.local/share/applications/pcsx2-Qt.desktop &>> /dev/null # delete old shortcut
 	else
 		return 1
 	fi

--- a/functions/EmuScripts/emuDeckPCSX2QT.sh
+++ b/functions/EmuScripts/emuDeckPCSX2QT.sh
@@ -15,7 +15,7 @@ PCSX2QT_install() {
 	echo "Begin PCSX2-QT Install"
 	local showProgress="$1"
 	
-	if installEmuAI "${PCSX2QT_emuName}" "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4749/pcsx2-v1.7.4749-linux-appimage-x64-Qt.AppImage" "pcsx2-Qt" "$showProgress"; then #pcsx2-Qt.AppImage	
+	if installEmuAI "${PCSX2QT_emuName}" "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4749/pcsx2-v1.7.4749-linux-appimage-x64-Qt.AppImage" "pcsx2-Qt" "$showProgress"; then # pcsx2-Qt.AppImage - filename capitalization matters for ES-DE to find it
 	#if installEmuAI "${PCSX2QT_emuName}" "$(getReleaseURLGH "PCSX2/pcsx2" "Qt.AppImage")" "pcsx2-Qt" "$showProgress"; then #pcsx2-Qt.AppImage
 		rm -rf $HOME/.local/share/applications/pcsx2-Qt.desktop &>> /dev/null # delete old shortcut
 	else

--- a/functions/EmuScripts/emuDeckRyujinx.sh
+++ b/functions/EmuScripts/emuDeckRyujinx.sh
@@ -14,7 +14,7 @@ Ryujinx_cleanup(){
 Ryujinx_install(){
     echo "Begin Ryujinx Install"
     local showProgress=$1
-    if installEmuBI "Ryujinx" "$(getReleaseURLGH "Ryujinx/release-channel-master" "-linux_x64.tar.gz")" "Ryujinx" "tar.gz" "$showProgress"; then
+    if installEmuBI "$Ryujinx_emuName" "$(getReleaseURLGH "Ryujinx/release-channel-master" "-linux_x64.tar.gz")" "" "tar.gz" "$showProgress"; then
         tar -xvf "$HOME/Applications/Ryujinx.tar.gz" -C "$HOME/Applications/" && rm -rf "$HOME/Applications/Ryujinx.tar.gz"
         chmod +x "$HOME/Applications/publish/Ryujinx"
     else

--- a/functions/EmuScripts/emuDeckVita3K.sh
+++ b/functions/EmuScripts/emuDeckVita3K.sh
@@ -15,7 +15,7 @@ Vita3K_cleanup(){
 Vita3K_install(){
     echo "Begin Vita3K Install"
     local showProgress="$1"
-    if installEmuBI "Vita3K" "$(getReleaseURLGH "Vita3K/Vita3K" "ubuntu-latest.zip")" "Vita3K" "zip" "$showProgress"; then
+    if installEmuBI "$Vita3K_emuName" "$(getReleaseURLGH "Vita3K/Vita3K" "ubuntu-latest.zip")" "" "zip" "$showProgress"; then
         unzip -o "$HOME/Applications/Vita3K.zip" -d "$Vita3K_emuPath" && rm -rf "$HOME/Applications/Vita3K.zip"
         chmod +x "$Vita3K_emuPath/Vita3K"
     else

--- a/functions/EmuScripts/emuDeckYuzu.sh
+++ b/functions/EmuScripts/emuDeckYuzu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #variables
-Yuzu_emuName="Yuzu"
+Yuzu_emuName="yuzu"
 Yuzu_emuType="AppImage"
 Yuzu_emuPath="$HOME/Applications/yuzu.AppImage"
 YuzuEA_emuPath="$HOME/Applications/yuzu-ea.AppImage"
@@ -29,7 +29,7 @@ Yuzu_install() {
     local lastVerFile="$HOME/emudeck/yuzu.ver"
     local latestVer=$(curl -fSs "https://api.github.com/repos/yuzu-emu/yuzu-mainline/releases" | jq -r '[ .[].tag_name ][0]')
     local success="false"
-    if installEmuAI "yuzu" "$(getReleaseURLGH "yuzu-emu/yuzu-mainline" "AppImage")" "" "$showProgress" "$lastVerFile" "$latestVer"; then #needs to be lowercase yuzu for EsDE to find it.
+    if installEmuAI "$Yuzu_emuName" "$(getReleaseURLGH "yuzu-emu/yuzu-mainline" "AppImage")" "" "$showProgress" "$lastVerFile" "$latestVer"; then # yuzu.AppImage - needs to be lowercase yuzu for EsDE to find it
         success="true"
     fi
 
@@ -44,8 +44,8 @@ Yuzu_init() {
 
     Yuzu_migrate
 
-    configEmuAI "yuzu" "config" "$HOME/.config/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/config/yuzu" "true"
-    configEmuAI "yuzu" "data" "$HOME/.local/share/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/data/yuzu" "true"
+    configEmuAI "$Yuzu_emuName" "config" "$HOME/.config/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/config/yuzu" "true"
+    configEmuAI "$Yuzu_emuName" "data" "$HOME/.local/share/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/data/yuzu" "true"
 
     Yuzu_setEmulationFolder
     Yuzu_setupStorage
@@ -60,8 +60,8 @@ Yuzu_update() {
 
     Yuzu_migrate
 
-    configEmuAI "yuzu" "config" "$HOME/.config/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/config/yuzu"
-    configEmuAI "yuzu" "data" "$HOME/.local/share/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/data/yuzu"
+    configEmuAI "$Yuzu_emuName" "config" "$HOME/.config/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/config/yuzu"
+    configEmuAI "$Yuzu_emuName" "data" "$HOME/.local/share/yuzu" "$EMUDECKGIT/configs/org.yuzu_emu.yuzu/data/yuzu"
 
     Yuzu_setEmulationFolder
     Yuzu_setupStorage
@@ -149,8 +149,7 @@ Yuzu_uninstall() {
 #Migrate
 Yuzu_migrate() {
     echo "Begin Yuzu Migration"
-    emu="Yuzu"
-    migrationFlag="$HOME/.config/EmuDeck/.${emu}MigrationCompleted"
+    migrationFlag="$HOME/.config/EmuDeck/.${Yuzu_emuName}MigrationCompleted"
     #check if we have a nomigrateflag for $emu
     if [ ! -f "$migrationFlag" ]; then
         #yuzu flatpak to appimage
@@ -160,6 +159,7 @@ Yuzu_migrate() {
         migrationTable+=("$HOME/.var/app/org.yuzu_emu.yuzu/config/yuzu" "$HOME/.config/yuzu")
 
         # migrateAndLinkConfig "$emu" "$migrationTable"
+        touch "${migrationFlag}"
     fi
 
     #move data from hidden folders out to these folders in case the user already put stuff here.

--- a/functions/installEmuAI.sh
+++ b/functions/installEmuAI.sh
@@ -2,27 +2,27 @@
 installEmuAI(){
     local name="$1"
     local url="$2"
-    local altName="$3"
+    local fileName="$3"
     local showProgress="$4"
     local lastVerFile="$5"
     local latestVer="$6"
 
-    if [[ "$altName" == "" ]]; then
-        altName="$name"
+    if [[ "$fileName" == "" ]]; then
+        fileName="$name"
     fi
     echo "$name"
     echo "$url"
-    echo "$altName"
+    echo "$fileName"
     echo "$showProgress"
     echo "$lastVerFile"
     echo "$latestVer"
 
-    #rm -f "$HOME/Applications/$altName.AppImage" # mv in safeDownload will overwrite...
+    #rm -f "$HOME/Applications/$fileName.AppImage" # mv in safeDownload will overwrite...
     mkdir -p "$HOME/Applications"
 
-    #curl -L "$url" -o "$HOME/Applications/$altName.AppImage.temp" && mv "$HOME/Applications/$altName.AppImage.temp" "$HOME/Applications/$altName.AppImage"
-    if safeDownload "$name" "$url" "$HOME/Applications/$altName.AppImage" "$showProgress"; then
-        chmod +x "$HOME/Applications/$altName.AppImage"
+    #curl -L "$url" -o "$HOME/Applications/$fileName.AppImage.temp" && mv "$HOME/Applications/$fileName.AppImage.temp" "$HOME/Applications/$fileName.AppImage"
+    if safeDownload "$name" "$url" "$HOME/Applications/$fileName.AppImage" "$showProgress"; then
+        chmod +x "$HOME/Applications/$fileName.AppImage"
         if [[ -n $lastVerFile ]] && [[ -n $latestVer ]]; then
             echo "latest version $latestVer > $lastVerFile"
             echo "$latestVer" > "$lastVerFile"
@@ -48,8 +48,8 @@ installEmuAI(){
         cp -v "$l" "${toolsPath}/launchers/"
         chmod +x "${toolsPath}/launchers/"*
 
-        createDesktopShortcut   "$HOME/.local/share/applications/$altName.desktop" \
-                                "$altName AppImage" \
+        createDesktopShortcut   "$HOME/.local/share/applications/$name.desktop" \
+                                "$name AppImage" \
                                 "${toolsPath}/launchers/$launcherFileName" \
                                 "false"
     done

--- a/functions/installEmuBI.sh
+++ b/functions/installEmuBI.sh
@@ -2,28 +2,28 @@
 installEmuBI(){
     local name="$1"
     local url="$2"
-    local altName="$3"
+    local fileName="$3"
     local format="$4"
     local showProgress="$5"
     local lastVerFile="$6"
     local latestVer="$7"
 
-    if [[ "$altName" == "" ]]; then
-        altName="$name"
+    if [[ "$fileName" == "" ]]; then
+        fileName="$name"
     fi
     echo "$name"
     echo "$url"
-    echo "$altName"
+    echo "$fileName"
     echo "$format"
     echo "$showProgress"
     echo "$lastVerFile"
     echo "$latestVer"
 
-    #rm -f "$HOME/Applications/$altName.$format" # mv below will overwrite...
+    #rm -f "$HOME/Applications/$fileName.$format" # mv below will overwrite...
     mkdir -p "$HOME/Applications"
 
-    #curl -L "$url" -o "$HOME/Applications/$altName.$format.temp" && mv "$HOME/Applications/$altName.$format.temp" "$HOME/Applications/$altName.$format"
-    if safeDownload "$name" "$url" "$HOME/Applications/$altName.$format" "$showProgress"; then
+    #curl -L "$url" -o "$HOME/Applications/$fileName.$format.temp" && mv "$HOME/Applications/$fileName.$format.temp" "$HOME/Applications/$fileName.$format"
+    if safeDownload "$name" "$url" "$HOME/Applications/$fileName.$format" "$showProgress"; then
         if [[ -n $lastVerFile ]] && [[ -n $latestVer ]]; then
             echo "latest version $latestVer > $lastVerFile"
             echo "$latestVer" > "$lastVerFile"
@@ -49,8 +49,8 @@ installEmuBI(){
         cp -v "$l" "${toolsPath}/launchers/"
         chmod +x "${toolsPath}/launchers/"*
 
-        createDesktopShortcut   "$HOME/.local/share/applications/$altName.desktop" \
-                                "$altName Binary" \
+        createDesktopShortcut   "$HOME/.local/share/applications/$name.desktop" \
+                                "$name Binary" \
                                 "${toolsPath}/launchers/$launcherFileName" \
                                 "false"
     done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -237,6 +237,7 @@ if [ "$doUninstall" == true ]; then
 		rm -rf $HOME/Applications/pcsx2-Qt.AppImage &>> /dev/null
 		rm -rf $HOME/.config/PCSX2 &>> /dev/null
 		rm -rf $HOME/.local/share/applications/pcsx2-Qt.desktop &>> /dev/null
+		rm -rf $HOME/.local/share/applications/PCSX2-Qt.desktop &>> /dev/null
 	fi
 	if [[ "$doUninstallPPSSPP" == true ]]; then
 		flatpak uninstall org.ppsspp.PPSSPP -y


### PR DESCRIPTION
* altName -> fileName
* fileName is used for the AppImage file name only, use the "real" name for the shortcut
* adapt emu scripts - only PCSX2 makes use of this
* small changes in other scripts to use emuName variable instead of hardcoded strings