### PR TITLE
helpers: Fix FlatPak installed check

### DIFF
--- a/functions/helperFunctions.sh
+++ b/functions/helperFunctions.sh
@@ -676,7 +676,7 @@ getEmuInstallStatus() {
 
 isFpInstalled(){
 	flatPakID=$1
-	if [ "$(flatpak --columns=app list --user | grep "$flatPakID")" == "$flatPakID" ] || [ "$(flatpak --columns=app list --system | grep "$flatPakID")" == "$flatPakID" ]; then
+	if (flatpak --columns=app list --user | grep -q "^$flatPakID$") || (flatpak --columns=app list --system | grep -q "^$flatPakID$"); then
 		echo "true"
 	else
 		echo "false"


### PR DESCRIPTION
The previous way of checking whether a package was installed or not was incorrect in its assumption, that a package ID will only occur once in the flatpak installed list.

I noticed this while trying to install PPSSPP, as FlatPak installs a `org.ppsspp.PPSSPP` and `org.ppsspp.PPSSPP.Locale` package. The package was installed correctly, but EmuDeck would register it as non-installed.