### PR TITLE
Update Vita3K's default config path

### DIFF
--- a/functions/EmuScripts/emuDeckVita3K.sh
+++ b/functions/EmuScripts/emuDeckVita3K.sh
@@ -4,7 +4,7 @@
 Vita3K_emuName="Vita3K"
 Vita3K_emuType="Binary"
 Vita3K_emuPath="$HOME/Applications/Vita3K"
-Vita3K_configFile="$HOME/Applications/Vita3K/config.yml"
+Vita3K_configFile="$HOME/.config/Vita3K/config.yml"
 
 #cleanupOlderThings
 Vita3K_cleanup(){


### PR DESCRIPTION
o/, this is my first PR here, im not sure if this is exactly the right thing to do but anyways, Vita3K changed where the config.yml file is located, now respecting XDG spec, defaulting to `~/.config/Vita3K/config.yml` if `XDG_CONFIG_HOME` is not set, also idk if its handled automatically the case where the Vita3K folder doesnt exist in .config, just a heads up. btw i was told to PR this to main branch as its a hotfix