### PR TITLE
Use local running instance of Jellyfin for default URL. This allows i…

### DIFF
--- a/tools/cloud/Jellyfin.sh
+++ b/tools/cloud/Jellyfin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-LINK="https://demo.jellyfin.org/stable"
+LINK="http://localhost:8096"
 
 source ./cloud.conf
 "/usr/bin/flatpak" run ${FLATPAKOPTIONS} ${BROWSERAPP} @@u @@ ${BROWSEROPTIONS} ${LINK}


### PR DESCRIPTION
…nstant access if Jellyfin server is installed and running on Steam Deck