### PR TITLE
fix fedora install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ elif [ $linuxID != "SteamOS" ]; then
         sudo pacman --noconfirm -S $ARCH_DEPS
     elif command -v dnf >/dev/null; then
         echo "Installing packages with dnf..."
-        FEDORA_DEPS="jq zenity flatpak unzip bash fuse git rsync whiptail"
+        FEDORA_DEPS="jq zenity flatpak unzip bash fuse git rsync newt"
 
         sudo dnf -y upgrade
         sudo dnf -y install $FEDORA_DEPS


### PR DESCRIPTION
whiptail package does not exist (at least on fedora 38).

It is available in the newt package.

![image](https://github.com/dragoonDorise/EmuDeck/assets/1045636/9bc6d9bd-c277-443b-9013-6e89e8905b65)
