### PR TITLE
Update RMG plugin configuration

### DIFF
--- a/configs/com.github.Rosalie241.RMG/config/RMG/mupen64plus.cfg
+++ b/configs/com.github.Rosalie241.RMG/config/RMG/mupen64plus.cfg
@@ -940,10 +940,10 @@ AnalogStickRight_ExtraData = "1"
 
 [Rosalie's Mupen GUI Core]
 
-GFX_Plugin = "/app/lib/RMG/Plugin/GFX/mupen64plus-video-GLideN64.so"
-AUDIO_Plugin = "/app/lib/RMG/Plugin/Audio/RMG-Audio.so"
-INPUT_Plugin = "/app/lib/RMG/Plugin/Input/RMG-Input.so"
-RSP_Plugin = "/app/lib/RMG/Plugin/RSP/mupen64plus-rsp-hle.so"
+GFX_Plugin = "mupen64plus-video-GLideN64.so"
+AUDIO_Plugin = "RMG-Audio.so"
+INPUT_Plugin = "RMG-Input.so"
+RSP_Plugin = "mupen64plus-rsp-hle.so"
 OverrideUserDirectories = True
 UserDataDirectory = "/home/deck/.var/app/com.github.Rosalie241.RMG/data/RMG"
 UserCacheDirectory = "/home/deck/.var/app/com.github.Rosalie241.RMG/cache/RMG"


### PR DESCRIPTION
Should make it a little more future proof due to RMG respecting `CMAKE_INSTALL_LIBDIR` now which breaks compatibility due to EmuDeck using the older configuration format where it uses the full path to plugins.

I'll push a fix to the flatpak aswell so this isn't urgent.