### PR TITLE
Add zenity progress bar to model 2 launcher

### DIFF
--- a/tools/launchers/model2.sh
+++ b/tools/launchers/model2.sh
@@ -5,9 +5,25 @@ GAMELAUNCHER=${toolsPath}/ULWGL/gamelauncher.sh
 
 EXE=$romsPath/model2/EMULATOR.EXE
 
-cd $romsPath/model2
+Model2Launcher="${toolsPath}/launchers/model2.sh"
 
+#In case the user deletes it, the script below does re-create it though
+mkdir -p "$romsPath/model2/pfx"
+
+while [ ! -d "$romsPath/model2/pfx/drive_c" ]; do
+
+    echo "Launching Model 2 for the first time. Downloading Protonfixes."
+
+    # $Model2_ProtonGEVersion is assigned in emuDeckModel2.sh
+    WINEPREFIX=$romsPath/model2/pfx/ GAMEID=ulwgl-model2 PROTONPATH="$HOME/.steam/steam/compatibilitytools.d/$Model2_ProtonGEVersion" $GAMELAUNCHER $Model2Launcher | zenity --progress --auto-close --pulsate --text="First time launching the Model 2 Emulator. Downloading protonfixes. Please be patient, this may take a while." --title="Model 2 Emulator" --width=600 --height=250 2>/dev/null
+
+done
+
+# Must launch ROMs from the same directory as EMULATOR.EXE
+cd $romsPath/model2
 
 # $Model2_ProtonGEVersion is assigned in emuDeckModel2.sh
 WINEPREFIX=$romsPath/model2/pfx/ GAMEID=ulwgl-model2 PROTONPATH="$HOME/.steam/steam/compatibilitytools.d/$Model2_ProtonGEVersion" $GAMELAUNCHER $EXE "${@}"
+
+
 


### PR DESCRIPTION
* Added zenity progress bar for downloading protonfixes 
   * Protonfixes may take approximately a minute to download, using this duct tape solution to show the user something