### PR TITLE
Adjust Model 2 config to use arcade platform in ES-DE

### DIFF
--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -77,7 +77,7 @@ Model2_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'extension' -v '.zip .ZIP' \
 		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/model2.sh %BASENAME%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "Model 2 Emulator (Proton)" \
-		--subnode '$newSystem' --type elem --name 'platform' -v 'model2' \
+		--subnode '$newSystem' --type elem --name 'platform' -v 'arcade' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'model2' \
 		-r 'systemList/system/commandP' -v 'command' \
 		"$es_systemsFile"


### PR DESCRIPTION
* Adjusted ES-DE to use arcade platform instead of model 2 for better scraping 
    * Matches ES-DE defaults