### PR TITLE
Use Quad9 instead of Google for Internet connectivity check.

### DIFF
--- a/tools/launchers/yuzu.sh
+++ b/tools/launchers/yuzu.sh
@@ -36,7 +36,7 @@ if [ -z "$1" ];then
     #check for noupdate flag
     if [ ! -e "${emuDontUpdate}" ]; then
         #check for network
-        if : >/dev/tcp/8.8.8.8/53; then
+        if : >/dev/tcp/9.9.9.9/53; then
             echo 'Internet available. Check for Update'
             #check if we are running mainline so we can offer to update
             if [ "$isMainline" = true ]; then


### PR DESCRIPTION
Some users need to blackhole 8.8.8.8 (and 8.8.4.4) to prevent Google-manufactured hardware (e.g. Chromecasts) from continuing to query Google when a custom DNS server should be used instead.

When 8.8.8.8 is blackholed, Yuzu will take several minutes to start.