### PR TITLE
Steam ROM Manager: BigPEmu Parser

### DIFF
--- a/configs/steam-rom-manager/userData/parsers/emudeck/atari_jaguar-bigpemu_proton.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/atari_jaguar-bigpemu_proton.json
@@ -1,63 +1,79 @@
 {
-      "parserType": "Glob",
-      "configTitle": "Atari Jaguar/Jaguar CD - BigPEmu Proton",
-      "steamCategory": "${Atari Jaguar}",
-      "executableArgs": "%command% \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": ["SteamGridDB"],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "defaultImage": "",
-      "defaultTallImage": "",
-      "defaultHeroImage": "",
-      "defaultLogoImage": "",
-      "defaultIcon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png",
-      "localImages": "",
-      "localTallImages": "",
-      "localHeroImages": "",
-      "localLogoImages": "",
-      "localIcons": "",
-      "disabled": false,
-      "executable": {
-        "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh",
-        "shortcutPassthrough": false,
-        "appendArgsToExecutable": false
-      },
-      "userAccounts": {
-        "specifiedAccounts": "",
-        "skipWithMissingDataDir": true,
-        "useCredentials": true
-      },
-      "parserInputs": {
-        "glob": "@(atarijaguar|atarijaguarcd)/**/${title}@(j64|.J64|.cof|.COF|.rom|.ROM|.jag|.JAG|.abs|.ABS|.zip|.ZIP|.cue|.CUE|.cdi|.CDI)"
-      },
-      "titleFromVariable": {
-        "limitToGroups": "",
-        "caseInsensitiveVariables": false,
-        "skipFileIfVariableWasNotFound": false,
-        "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-        "replaceDiacritics": true,
-        "removeCharacters": true,
-        "removeBrackets": true
-      },
-      "parserId": "164824416518097459",
-      "version": 1,
-      "imageProviderAPIs": {
-        "SteamGridDB": {
+  "parserType": "Glob",
+  "configTitle": "Atari Jaguar/Jaguar CD - BigPEmu Proton",
+  "steamDirectory": "${steamdirglobal}",
+  "steamCategory": "${Atari Jaguar}",
+  "romDirectory": "${romsdirglobal}",
+  "executableArgs": "%command% \"${filePath}\"",
+  "executableModifier": "\"${exePath}\"",
+  "startInDirectory": "",
+  "titleModifier": "${fuzzyTitle}",
+  "fetchControllerTemplatesButton": null,
+  "removeControllersButton": null,
+  "imageProviders": [
+      "SteamGridDB"
+  ],
+  "onlineImageQueries": "${${fuzzyTitle}}",
+  "imagePool": "${fuzzyTitle}",
+  "userAccounts": {
+      "specifiedAccounts": ""
+  },
+  "executable": {
+      "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+  },
+  "parserInputs": {
+      "glob": "@(atarijaguar|atarijaguarcd)/**/${title}@(j64|.J64|.cof|.COF|.rom|.ROM|.jag|.JAG|.abs|.ABS|.zip|.ZIP|.cue|.CUE|.cdi|.CDI)"
+  },
+  "titleFromVariable": {
+      "limitToGroups": "",
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "tryToMatchTitle": false
+  },
+  "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+  },
+  "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+  },
+  "imageProviderAPIs": {
+      "SteamGridDB": {
           "nsfw": false,
           "humor": false,
-          "imageMotionTypes": ["static"],
           "styles": [],
           "stylesHero": [],
           "stylesLogo": [],
-          "stylesIcon": []
-        }
+          "stylesIcon": [],
+          "imageMotionTypes": [
+              "static"
+          ]
       }
-    }
-  
+  },
+  "defaultImage": {
+      "tall": "",
+      "long": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+  },
+  "localImages": {
+      "tall": "",
+      "long": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+  },
+  "parserId": "164824416518097459",
+  "version": 15
+}


### PR DESCRIPTION
* BigPEmu Parser 
   * Removed fallback icon 
   * Fixed executable field not populating 
   * Updated parser to latest format (Through Steam ROM Manager)