### PR TITLE
Supermodel Controls

### DIFF
--- a/configs/supermodel/Config/Supermodel.ini
+++ b/configs/supermodel/Config/Supermodel.ini
@@ -73,7 +73,7 @@ Balance = 10
 MusicVolume = 100
 SoundVolume = 115
 Balance = 0
-InputSystem=rawinput
+
 
 [ lemans24 ]
 MusicVolume = 100
@@ -85,7 +85,7 @@ InputJoy1XSaturation = 120
 MusicVolume = 100
 SoundVolume = 105
 Balance = 20
-InputSystem=rawinput
+
 
 [ magtruck ]
 MusicVolume = 100
@@ -101,13 +101,13 @@ Balance = 15
 MusicVolume = 100
 SoundVolume = 100
 Balance = 0
-InputSystem=rawinput
+
 
 [ oceanhuna ]
 MusicVolume = 100
 SoundVolume = 100
 Balance = 0
-InputSystem=rawinput
+
 
 [ scud ]
 MusicVolume = 200
@@ -157,7 +157,7 @@ InputJoy1XSaturation = 150
 MusicVolume = 100
 SoundVolume = 100
 Balance = 0
-InputSystem=rawinput
+
 
 [ vf3 ]
 MusicVolume = 100
@@ -330,10 +330,10 @@ InputAnalogJoyLeft = "NONE"             ; digital, move left
 InputAnalogJoyRight = "NONE"            ; digital, move right
 InputAnalogJoyUp = "NONE"               ; digital, move up
 InputAnalogJoyDown = "NONE"             ; digital, move down
-InputAnalogJoyX = "JOY1_XAXIS_INV,MOUSE1_XAXIS_INV"   ; analog, full X axis
-InputAnalogJoyY = "JOY1_YAXIS_INV,MOUSE1_YAXIS"   ; analog, full Y axis
-InputAnalogJoyTrigger = "JOY1_ZAXIS_NEG,JOY1_BUTTON3,MOUSE1_LEFT_BUTTON"
-InputAnalogJoyEvent = "JOY1_BUTTON1,MOUSE1_RIGHT_BUTTON"
+InputAnalogJoyX = "JOY1_XAXIS_INV,MOUSE_XAXIS_INV"   ; analog, full X axis
+InputAnalogJoyY = "JOY1_YAXIS_INV,MOUSE_YAXIS"   ; analog, full Y axis
+InputAnalogJoyTrigger = "JOY1_ZAXIS_NEG,JOY1_BUTTON3,MOUSE_LEFT_BUTTON"
+InputAnalogJoyEvent = "JOY1_BUTTON1,JOY1_BUTTON11,MOUSE_RIGHT_BUTTON"
 InputAnalogJoyTrigger2 = "NONE"
 InputAnalogJoyEvent2 = "NONE"
 
@@ -342,10 +342,10 @@ InputGunLeft = "NONE"                 ; digital, move gun left
 InputGunRight = "NONE"                ; digital, move gun right
 InputGunUp = "NONE"                   ; digital, move gun up
 InputGunDown = "NONE"                 ; digital, move gun down
-InputGunX = "JOY1_XAXIS,MOUSE1_XAXIS"    ; analog, full X axis
-InputGunY = "JOY1_YAXIS,MOUSE1_YAXIS"    ; analog, full Y axis
-InputTrigger = "JOY1_ZAXIS_NEG,JOY1_BUTTON3,MOUSE1_LEFT_BUTTON"
-InputOffscreen = "MOUSE1_RIGHT_BUTTON,JOY1_BUTTON1"    ; point off-screen
+InputGunX = "JOY1_XAXIS,MOUSE_XAXIS"    ; analog, full X axis
+InputGunY = "JOY1_YAXIS,MOUSE_YAXIS"    ; analog, full Y axis
+InputTrigger = "JOY1_ZAXIS_NEG,JOY1_BUTTON3,MOUSE_LEFT_BUTTON"
+InputOffscreen = "MOUSE_RIGHT_BUTTON,JOY1_BUTTON1,JOY1_BUTTON11"    ; point off-screen
 InputAutoTrigger = 1                    ; automatic reload when off-screen
 InputGunLeft2 = "NONE"
 InputGunRight2 = "NONE"
@@ -362,10 +362,10 @@ InputAnalogGunLeft = "NONE"               ; digital, move gun left
 InputAnalogGunRight = "NONE"              ; digital, move gun right
 InputAnalogGunUp = "NONE"                 ; digital, move gun up
 InputAnalogGunDown = "NONE"               ; digital, move gun down
-InputAnalogGunX = "JOY1_XAXIS,MOUSE1_XAXIS"    ; analog, full X axis
-InputAnalogGunY = "JOY1_YAXIS,MOUSE1_YAXIS"    ; analog, full Y axis
-InputAnalogTriggerLeft = "JOY1_ZAXIS_NEG,JOY1_BUTTON3,MOUSE1_LEFT_BUTTON"    ;Lost World trigger
-InputAnalogTriggerRight = "JOY1_BUTTON1,MOUSE1_RIGHT_BUTTON"    ;Lost World off-screen
+InputAnalogGunX = "JOY1_XAXIS,MOUSE_XAXIS"    ; analog, full X axis
+InputAnalogGunY = "JOY1_YAXIS,MOUSE_YAXIS"    ; analog, full Y axis
+InputAnalogTriggerLeft = "JOY1_ZAXIS_NEG,JOY1_BUTTON3,MOUSE_LEFT_BUTTON"    ;Lost World trigger
+InputAnalogTriggerRight = "JOY1_BUTTON1,JOY1_BUTTON11,MOUSE_RIGHT_BUTTON"    ;Lost World off-screen
 InputAnalogGunLeft2 = "NONE"
 InputAnalogGunRight2 = "NONE"
 InputAnalogGunUp2 = "NONE"
@@ -426,8 +426,8 @@ Throttle=0
 ShowFrameRate=1
 FlipStereo=0
 VSync=1
-XResolution=1920
-YResolution=1080
+XResolution=1280
+YResolution=800
 EmulateDSB=1
 NbSoundChannels=4
 ForceFeedback=1
@@ -435,6 +435,7 @@ port_in=1970
 port_out=port_out
 addr_out=addr_out
 EmulateNet=0
+InputSystem=sdl
 InputJoy1XDeadZone=7
 InputJoy1YDeadZone=7
 InputJoy2XDeadZone=7


### PR DESCRIPTION
* Removed rawinput, not working on Steam Deck
* Set input driver to SDL
* Updated mouse inputs so right trackpad on Steam Deck works ootb 
    * I don't have light guns so I am not sure if the mouse2 inputs need to be updated to mouse1 or not
* Added R3 as an alternative input for the "A" button in lightgun games so "Gamepad with Mouse Trackpad" works OOTB
* Set resolution to 1280x800p so right trackpad can reach the entire screen