### PR TITLE
DuckStation Hotkeys Hotfix 

### DIFF
--- a/configs/org.duckstation.DuckStation/config/duckstation/settings.ini
+++ b/configs/org.duckstation.DuckStation/config/duckstation/settings.ini
@@ -387,8 +387,6 @@ DecreaseResolutionScale = SDL-0/Start & SDL-0/DPadDown
 ToggleWidescreen = SDL-0/Start & SDL-0/DPadRight
 TogglePGXP = SDL-0/Back & SDL-0/Y
 ToggleSoftwareRendering = SDL-0/Start & SDL-0/DPadLeft
-TogglePGXP = SDL-0/Start & SDL-0/DPadLeft
-ToggleSoftwareRendering = SDL-0/Start & SDL-0/LeftStick
 PowerOff = SDL-0/Back & SDL-0/Start
 
 [UI]


### PR DESCRIPTION
* Removed duplicate hotkeys - PGXP and Software Rendering 
   * Duplicates were still in conflict with other hotkeys (quick menu and the new software rendering hotkey)