### PR TITLE
Tidy up Proton Uninstall Functions

### DIFF
--- a/functions/EmuScripts/emuDeckBigPEmu.sh
+++ b/functions/EmuScripts/emuDeckBigPEmu.sh
@@ -138,8 +138,8 @@ BigPEmu_wipeSettings(){
 
 #Uninstall
 BigPEmu_uninstall(){
-	setMSG "Uninstalling $BigPEmu_emuName."
-	rm -rf "${BigPEmu_emuPath}"
+	setMSG "Uninstalling $BigPEmu_emuName. ROMs will be retained in the ROMs folder. Saves will be retained in "$HOME/Applications/BigPEmu/UserData"."
+	find "$HOME/Applications/BigPEmu" -mindepth 1 -name UserData -prune -o -exec rm -rf '{}' \; &>> /dev/null
     rm -rf "$HOME/.local/share/applications/BigPEmu (Proton).desktop"
     BigPEmu_wipeSettings
 }

--- a/functions/EmuScripts/emuDeckCemuProton.sh
+++ b/functions/EmuScripts/emuDeckCemuProton.sh
@@ -178,7 +178,8 @@ CemuProton_wipeSettings(){
 #Uninstall
 CemuProton_uninstall(){
 	setMSG "Uninstalling $CemuProton_emuName."
-	rm -rf "${CemuProton_emuPath}"
+	find ${romsPath}/wiiu -mindepth 1 \( -name roms -o -name mlc01 \) -prune -o -exec rm -rf '{}' \; &>> /dev/null
+	rm -f "$HOME/.local/share/applications/Cemu (Proton).desktop" &> /dev/null
 }
 
 #setABXYstyle

--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -105,8 +105,8 @@ Model2_wipeSettings(){
 
 #Uninstall
 Model2_uninstall(){
-	setMSG "Uninstalling $Model2_emuName."
-	rm -rf "${Model2_emuPath}"
+	setMSG "Uninstalling $Model2_emuName. Saves and ROMs will be retained in the ROMs folder."
+	find ${romsPath}/model2 -mindepth 1 -name roms -prune -o -exec rm -rf '{}' \; &>> /dev/null
     rm -rf "$HOME/.local/share/applications/Model 2 (Proton).desktop"
     Model2_wipeSettings
 }

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -63,6 +63,7 @@ Xenia_init(){
 	rsync -avhp "$EMUDECKGIT/configs/xenia/" "$romsPath/xbox360"
 	mkdir -p "$romsPath/xbox360/roms/xbla"
 	Xenia_addESConfig
+	Xenia_setupSaves
 }
 
 Xenia_addESConfig(){
@@ -136,6 +137,7 @@ function Xenia_getPatches() {
 #update
 Xenia_update(){
 	echo "NYI"
+	Xenia_setupSaves
 }
 
 #ConfigurePaths
@@ -145,7 +147,8 @@ Xenia_setEmulationFolder(){
 
 #SetupSaves
 Xenia_setupSaves(){
-	linkToSaveFolder xenia saves "$romsPath/xenia/content"
+	mkdir -p "$romsPath/xbox360/content"
+	linkToSaveFolder xenia saves "$romsPath/xbox360/content"
 }
 
 
@@ -163,7 +166,9 @@ Xenia_wipeSettings(){
 
 #Uninstall
 Xenia_uninstall(){
-	rm -rf "${Xenia_emuPath}"
+	setMSG "Uninstalling $Xenia_emuName. Saves and ROMs will be retained in the ROMs folder."
+	find ${romsPath}/xbox360 -mindepth 1 \( -name roms -o -name content \) -prune -o -exec rm -rf '{}' \; &>> /dev/null
+	rm -rf $HOME/.local/share/applications/xenia.desktop &> /dev/null
 }
 
 #setABXYstyle

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -363,10 +363,14 @@ fi
 	if [[ "$doUninstallSupermodel" == true ]]; then
 		flatpak uninstall com.supermodel3.Supermodel -y
 		rm -rf $HOME/.var/app/com.supermodel3.Supermodel &>> /dev/null
+		rm -rf $HOME/.config/supermodel &>> /dev/null
 		rm -rf $HOME/.supermodel &>> /dev/null
+		rm -rf $HOME/.local/share/supermodel &>> /dev/null
 	fi
 	if [[ "$doUninstallVita3K" == true ]]; then
 		rm -rf $HOME/Applications/Vita3K &> /dev/null
+		rm -rf $HOME/.cache/Vita3K &> /dev/null
+		rm -rf $HOME/.config/Vita3K &> /dev/null
 		rm -rf $HOME/.local/share/Vita3K &> /dev/null
 		rm -rf $HOME/.local/share/applications/Vita3K.desktop &> /dev/null
 	fi
@@ -439,6 +443,8 @@ fi
 	rm -rf $HOME/Desktop/EmuDeckSD.desktop &> /dev/null
 	rm -rf $HOME/Desktop/EmuDeckBinUpdate.desktop &> /dev/null
 	rm -rf $HOME/Desktop/SteamRomManager.desktop &> /dev/null
+	rm -rf $HOME/Desktop/uninstall-sdgyrodsu.desktop &> /dev/null
+	rm -rf $HOME/Desktop/update-sdgyrodsu.desktop &> /dev/null
 	rm -rf $HOME/Applications/EmuDeck.AppImage &> /dev/null
 	rm -rf $HOME/Applications/EmuDeck_SaveSync.AppImage &> /dev/null
 	rm -rf $HOME/Applications/RemotePlayWhatever.AppImage &> /dev/null


### PR DESCRIPTION
* Fixed uninstall methods for BigPEmu, Cemu Proton, Model 2, and Xenia 
    * The individual uninstall button in the EmuDeck application will wipe everything except the ROMs and saves folder
    * The global uninstall script will save BIOS and saves on request but will wipe everything else otherwise
* Fixed Xenia save paths (so the uninstall bit works properly)