### PR TITLE
Steam ROM Manager: Fix RPCS3 and Flycast parsers

### DIFF
--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade_atomiswave-flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade_atomiswave-flycast.json
@@ -24,13 +24,13 @@
           "appendArgsToExecutable": false
       },
       "parserInputs": {
-        "glob": "**/${title}@(.zip|.ZIP)"
+        "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
       },
       "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
+        "limitToGroups": "${MAME}",
+        "caseInsensitiveVariables": false,
+        "skipFileIfVariableWasNotFound": false,
+        "tryToMatchTitle": true
       },
       "fuzzyMatch": {
           "replaceDiacritics": true,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi-flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi-flycast.json
@@ -7,7 +7,7 @@
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "\"'${filePath}'\"",
+  "executableArgs": "\"${filePath}\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],
@@ -16,13 +16,13 @@
     "specifiedAccounts": ""
   },
   "parserInputs": {
-    "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI|.m3u|.M3U)"
+    "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
   },
   "titleFromVariable": {
-    "limitToGroups": "",
+    "limitToGroups": "${MAME}",
     "caseInsensitiveVariables": false,
     "skipFileIfVariableWasNotFound": false,
-    "tryToMatchTitle": false
+    "tryToMatchTitle": true
   },
   "fuzzyMatch": {
     "replaceDiacritics": true,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi-ra-flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi-ra-flycast.json
@@ -33,7 +33,7 @@
     "appendArgsToExecutable": true
   },
   "parserInputs": {
-    "glob": "**/${title}@(.zip|.ZIP)"
+    "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
   },
   "titleFromVariable": {
     "limitToGroups": "${MAME}",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi2-flycast.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/arcade_naomi2-flycast.json
@@ -22,13 +22,13 @@
     "appendArgsToExecutable": false
   },
   "parserInputs": {
-    "glob": "**/${title}@(.zip|.ZIP)"
+    "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
   },
   "titleFromVariable": {
-    "limitToGroups": "",
+    "limitToGroups": "${MAME}",
     "caseInsensitiveVariables": false,
     "skipFileIfVariableWasNotFound": false,
-    "tryToMatchTitle": false
+    "tryToMatchTitle": true
   },
   "fuzzyMatch": {
     "replaceDiacritics": true,

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-extracted_iso_psn.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-extracted_iso_psn.json
@@ -7,7 +7,7 @@
   "steamDirectory": "${steamdirglobal}",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",
-  "executableArgs": "--no-gui \"${filePath}\"",
+  "executableArgs": "--no-gui \"'${filePath}'\"",
   "onlineImageQueries": "${${fuzzyTitle}}",
   "imagePool": "${fuzzyTitle}",
   "imageProviders": ["SteamGridDB"],

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-pkg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-pkg.json
@@ -4,7 +4,7 @@
   "steamCategory": "${Sony PlayStation 3}",
   "steamDirectory": "${steamdirglobal}",
   "romDirectory": "/run/media/mmcblk0p1/Emulation/storage/rpcs3/dev_hdd0/game",
-  "executableArgs": "--no-gui \"${filePath}\"",
+  "executableArgs": "--no-gui \"'${filePath}'\"",
   "executableModifier": "\"${exePath}\"",
   "startInDirectory": "",
   "titleModifier": "${fuzzyTitle}",


### PR DESCRIPTION
* Fixed RPCS3 ROMs not being escaped properly
* Fixed extra quote in Flycast parser
* Fixed file formats in Flycast arcade parsers
* Fixed fuzzy matching in Flycast arcade parsers