### PR TITLE
Model 2 Emulator: Rename launcher

### DIFF
--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -25,7 +25,7 @@
     <fullname>Sega Model 2</fullname>
     <path>%ROMPATH%/model2/roms</path>
     <extension>.zip .ZIP</extension>
-    <command label="Model 2 Emulator (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/model2.sh %BASENAME%</command>
+    <command label="Model 2 Emulator (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/model-2-emulator.sh %BASENAME%</command>
     <platform>arcade</platform>
     <theme>model2</theme>
   </system>

--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -32,11 +32,11 @@ Model2_install(){
 		return 1
 	fi
 
-	cp "$EMUDECKGIT/tools/launchers/model2.sh" "$toolsPath/launchers/model2.sh"
+	cp "$EMUDECKGIT/tools/launchers/model-2-emulator.sh" "$toolsPath/launchers/model-2-emulator.sh"
 
   	createDesktopShortcut   "$HOME/.local/share/applications/Model 2 Emulator (Proton).desktop" \
 							"$Model2_emuName (Proton)" \
-							"${toolsPath}/launchers/model2.sh"  \
+							"${toolsPath}/launchers/model-2-emulator.sh"  \
 							"False"
 
 
@@ -66,7 +66,7 @@ Model2_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Sega Model 2' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/model2/roms' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/model2.sh %BASENAME%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "Model 2 Emulator (Proton)" \
 		--subnode '$newSystem' --type elem --name 'platform' -v 'arcade' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'model2' \

--- a/functions/ToolScripts/emuDeckESDE.sh
+++ b/functions/ToolScripts/emuDeckESDE.sh
@@ -275,7 +275,7 @@ ESDE_setEmulationFolder(){
 	if [[ ! $(grep -rnw "$es_systemsFile" -e 'model2') == "" ]]; then
 		if [[ $(grep -rnw "$es_systemsFile" -e 'Model 2 Emulator (Proton)') == "" ]]; then
 			#insert
-			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="model2"]' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/model2.sh %BASENAME%" \
+			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="model2"]' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%" \
 			--insert 'systemList/system/commandP' --type attr --name 'label' --value "Model 2 Emulator (Proton)" \
 			-r 'systemList/system/commandP' -v 'command' \
 			"$es_systemsFile"
@@ -284,7 +284,7 @@ ESDE_setEmulationFolder(){
 			xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 		else
 			#update
-			model2ProtonCommandString="/bin/bash ${toolsPath}/launchers/model2.sh %BASENAME%"
+			model2ProtonCommandString="/bin/bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%"
 			xmlstarlet ed -L -u '/systemList/system/command[@label="Model 2 Emulator (Proton)"]' -v "$model2ProtonCommandString" "$es_systemsFile"
 		fi
 	fi

--- a/tools/launchers/model-2-emulator.sh
+++ b/tools/launchers/model-2-emulator.sh
@@ -6,7 +6,7 @@ GAMELAUNCHER=$ULWGL_toolPath/ulwgl-run
 
 EXE="$romsPath/model2/EMULATOR.EXE"
 
-Model2Launcher="${toolsPath}/launchers/model2.sh"
+Model2Launcher="${toolsPath}/launchers/model-2-emulator.sh"
 
 #In case the user deletes it, will allow loading bar to pop up again.
 mkdir -p "$romsPath/model2/pfx"


### PR DESCRIPTION
* The old name was triggering mismatches on SteamGridDB