### PR TITLE
Xenia: Fix ES-DE detection + clean up custom systems

### DIFF
--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -5,7 +5,7 @@
     <fullname>Atari Jaguar</fullname>
     <path>%ROMPATH%/atarijaguar</path>
     <extension>.abs .ABS .bin .BIN .cdi .CDI .cof .COF .cue .CUE .j64 .J64 .jag .JAG .prg .PRG .rom .ROM .7z .7Z .zip .ZIP</extension>
-    <command label="BigPEmu (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/bigpemu.sh %ROM%</command>
+    <command label="BigPEmu (Proton)">/bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh %ROM%</command>
     <command label="Virtual Jaguar">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/virtualjaguar_libretro.so %ROM%</command>
     <command label="MAME (Standalone)">%STARTDIR%=~/.mame %EMULATOR_MAME% -rompath %GAMEDIR%\;%ROMPATH%/atarijaguar jaguar -cart %ROM%</command>
     <platform>atarijaguar</platform>
@@ -16,7 +16,7 @@
     <fullname>Atari Jaguar CD</fullname>
     <path>%ROMPATH%/atarijaguarcd</path>
     <extension>.abs .ABS .bin .BIN .cdi .CDI .cof .COF .cue .CUE .j64 .J64 .jag .JAG .prg .PRG .rom .ROM .7z .7Z .zip .ZIP</extension>
-    <command label="BigPEmu (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/bigpemu.sh %ROM%</command>
+    <command label="BigPEmu (Proton)">/bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh %ROM%</command>
     <platform>atarijaguarcd</platform>
     <theme>atarijaguarcd</theme>
   </system>
@@ -25,7 +25,7 @@
     <fullname>Sega Model 2</fullname>
     <path>%ROMPATH%/model2/roms</path>
     <extension>.zip .ZIP</extension>
-    <command label="Model 2 Emulator (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/model-2-emulator.sh %BASENAME%</command>
+    <command label="Model 2 Emulator (Proton)">/bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/model-2-emulator.sh %BASENAME%</command>
     <platform>arcade</platform>
     <theme>model2</theme>
   </system>
@@ -44,7 +44,7 @@
     <fullname>Microsoft Xbox 360</fullname>
     <path>%ROMPATH%/xbox360/roms</path>
     <extension>.iso .ISO . .xex .XEX</extension>
-    <command label="Xenia (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/xenia.sh z:%ROM%</command>
+    <command label="Xenia (Proton)">/bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh z:%ROM%</command>
     <platform>xbox360</platform>
     <theme>xbox360</theme>
   </system>
@@ -53,8 +53,8 @@
     <fullname>Nintendo Wii U</fullname>
     <path>%ROMPATH%/wiiu/roms</path>
     <extension>.rpx .RPX .wud .WUD .wux .WUX .elf .ELF .iso .ISO .wad .WAD .wua .WUA</extension>
-    <command label="Cemu (Native)">/bin/bash /run/media/mmcblk0p1/tools/launchers/cemu.sh -f -g %ROM%</command>
-    <command label="Cemu (Proton)">/bin/bash /run/media/mmcblk0p1/tools/launchers/cemu.sh -w -f -g z:%ROM%</command>
+    <command label="Cemu (Native)">/bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh -f -g %ROM%</command>
+    <command label="Cemu (Proton)">/bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh -w -f -g z:%ROM%</command>
     <platform>wiiu</platform>
     <theme>wiiu</theme>
   </system>

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -35,6 +35,8 @@ Xenia_install(){
 		rsync -avzh "$romsPath"/xbox360/tmp/ "$romsPath"/xbox360/
 		rm -rf "$romsPath"/xbox360/tmp
 		rm -f "$romsPath"/xbox360/xenia.zip
+		# Prevents it from showing up in ES-DE
+		mv -f "$romsPath/xbox360/LICENSE" "$romsPath/xbox360/LICENSE.TXT"
 	else
 		return 1
 	fi
@@ -49,7 +51,8 @@ Xenia_install(){
 #	fi
 	chmod +x "${toolsPath}/launchers/xenia.sh"
 
-    Xenia_getPatches
+	Xenia_getPatches
+	Xenia_cleanESDE
 
 	createDesktopShortcut   "$HOME/.local/share/applications/xenia.desktop" \
 							"Xenia (Proton)" \
@@ -64,6 +67,7 @@ Xenia_init(){
 	mkdir -p "$romsPath/xbox360/roms/xbla"
 	Xenia_setupSaves
 	#SRM_createParsers
+	Xenia_cleanESDE
 
 
 	if [ -e "$ESDE_toolPath" ]; then
@@ -71,6 +75,7 @@ Xenia_init(){
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
+
 }
 
 Xenia_addESConfig(){
@@ -95,49 +100,17 @@ Xenia_addESConfig(){
 }
 
 function Xenia_getPatches() {
-  local patches_dir="${romsPath}/xbox360/"
-  local patches_repo="https://github.com/xenia-canary/game-patches.git"
-  local patches_branch="main"
+	local patches_url="https://github.com/xenia-canary/game-patches/releases/latest/download/game-patches.zip"
 
-  # Create the patches directory if it doesn't exist
-  if [ ! -d "$patches_dir" ]; then
-    mkdir -p "$patches_dir"
-  fi
+	mkdir -p "${romsPath}/xbox360/patches"
+	if  [[ ! "$( ls -A "${romsPath}/xbox360/patches")" ]] ; then
+		{ curl -L "$patches_url" -o "${romsPath}/xbox360/game-patches.zip" && nice -n 5 unzip -q -o "${romsPath}/xbox360/game-patches.zip" -d "${romsPath}/xbox360" && rm "${romsPath}/xbox360/game-patches.zip"; } &> /dev/null
+		echo "Xenia patches downloaded." 
+	else 
+		{ curl -L "$patches_url" -o "${romsPath}/xbox360/game-patches.zip" && nice -n 5 unzip -q -u "${romsPath}/xbox360/game-patches.zip" -d "${romsPath}/xbox360" && rm "${romsPath}/xbox360/game-patches.zip"; } &> /dev/null
+		echo "Xenia patches updated." 
+	fi
 
-  # Initialize a new Git repository in the patches directory
-  cd "$patches_dir" || exit
-  if ! git rev-parse --git-dir > /dev/null 2>&1; then
-    git init
-  fi
-
-  # Set up a remote origin for the repository
-  if ! git remote get-url origin > /dev/null 2>&1; then
-    git remote add origin "$patches_repo"
-  fi
-
-  # Configure Git to perform a sparse checkout of the patches folder
-  if ! git config core.sparsecheckout > /dev/null 2>&1; then
-    git config core.sparsecheckout true
-  fi
-  if ! grep -Fxq "patches/*" .git/info/sparse-checkout; then
-    echo "patches/*" >> .git/info/sparse-checkout
-  fi
-
-  # Pull the latest changes from the remote repository
-  git fetch --depth=1 origin "$patches_branch"
-  if git merge FETCH_HEAD > /dev/null 2>&1; then
-    echo "Patches updated successfully"
-  else
-    # If the merge failed, reset the local changes and try again
-    git reset --hard HEAD > /dev/null 2>&1
-    git clean -fd > /dev/null 2>&1
-    git fetch --depth=1 origin "$patches_branch"
-    if git merge FETCH_HEAD > /dev/null 2>&1; then
-      echo "Patches updated successfully"
-    else
-      echo "Error: Failed to update patches"
-    fi
-  fi
 }
 
 
@@ -229,4 +202,20 @@ Xenia_resetConfig(){
 Xenia_setResolution(){
 	$xeniaResolution
 	echo "NYI"
+}
+
+Xenia_cleanESDE(){
+
+	# These files/folders make it so if you have no ROMs in xbox360, it still shows up as an "active" system.
+
+	if [ -d "${romsPath}/xbox360/.git" ]; then
+		rm -rf "${romsPath}/xbox360/.git"
+	fi
+
+	if [ -f "$romsPath/xbox360/LICENSE" ]; then 
+		mv -f "$romsPath/xbox360/LICENSE" "$romsPath/xbox360/LICENSE.TXT"
+	fi
+
+
+
 }

--- a/functions/ToolScripts/emuDeckPegasus.sh
+++ b/functions/ToolScripts/emuDeckPegasus.sh
@@ -44,7 +44,7 @@ pegasus_init(){
 
 	for systemPath in "$romsPath"/*; do rm -rf "$systemPath/media" &> /dev/null; done
 
-	for systemPath in "$romsPath"/*; do system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/'); mkdir -p "$toolsPath/downloaded_media/$system/covers"; rm -rf "$toolsPath/downloaded_media/$system/box2dfront" ; mkdir -p "$toolsPath/downloaded_media/$system/marquees"; rm -rf "$toolsPath/downloaded_media/$system/wheel" &> /dev/null;rm -rf "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null; done
+	for systemPath in "$romsPath"/*; do system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/'); mkdir -p "$toolsPath/downloaded_media/$system/covers"; rm -rf "$toolsPath/downloaded_media/$system/box2dfront" ; mkdir -p "$toolsPath/downloaded_media/$system/marquees"; rm -rf "$toolsPath/downloaded_media/$system/wheel" &> /dev/null; rm -rf "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null; mkdir -p "$toolsPath/downloaded_media/$system/screenshots/"; done
 
 	for systemPath in "$romsPath"/*; do system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/'); ln -s "$toolsPath/downloaded_media/$system" "$systemPath/media" &> /dev/null; ln -s "$toolsPath/downloaded_media/$system/covers/" "$toolsPath/downloaded_media/$system/box2dfront" &> /dev/null; ln -s "$toolsPath/downloaded_media/$system/marquees/" "$toolsPath/downloaded_media/$system/wheel" &> /dev/null; ln -s "$toolsPath/downloaded_media/$system/screenshots/" "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null; done
 


### PR DESCRIPTION
* A broken media symlink for Pegasus was causing ES-DE to detect it as a ROM. 
   * Now creates this folder on reset.
* The LICENSE file was causing ES-DE to detect it as a ROM. 
    * Renamed LICENSE to LICENSE.TEXT
* .git was being detected as a ROM. 
    * Removed this and replaced how xenia grabs patches.

Closes: https://github.com/dragoonDorise/EmuDeck/issues/1078