### PR TITLE
Uninstall: Fix pegasus uninstall

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -494,6 +494,8 @@ fi
 	# Pegasus
 	flatpak uninstall org.pegasus_frontend.Pegasus -y
 	rm -rf "$HOME/.var/app/org.pegasus_frontend.Pegasus/" &> /dev/null 
+	rm -rf $HOME/Applications/pegasus-fe &> /dev/null 
+	rm -rf $HOME/.config/pegasus-frontend &> /dev/null 
 
 	echo "90"
 	echo "# Removing EmuDeck folders";


### PR DESCRIPTION
Since Pegasus was swapped over to the binary, it uses new config folders.