### PR TITLE
Cloud Backup: fixes to ensure previous cloud backup setups continue to work

### DIFF
--- a/functions/ToolScripts/emuDeckCloudBackup.sh
+++ b/functions/ToolScripts/emuDeckCloudBackup.sh
@@ -169,7 +169,7 @@ cloud_backup_providersSetup(){
 cloud_backup_setup(){
 
     while true; do
-        if [ ! -e "$rclone_bin" ] || [ ! -e "$rclone_jobScript" ];  then
+        if [ ! -e "$rclone_bin" ] || [ ! -e "$cloud_backup_jobScript" ];  then
             ans=$(zenity --info --title 'cloud_backup' \
                         --text 'Click on Install to continue' \
                         --width=50 \
@@ -209,7 +209,7 @@ cloud_backup_setup(){
 
 cloud_backup_createJob(){
 
-echo '#!/bin/bash'>"$rclone_jobScript"
+echo '#!/bin/bash'>"$cloud_backup_jobScript"
 echo "source \$HOME/emudeck/settings.sh
 PIDFILE=\"\$toolsPath/rclone/rclone.pid\"
 
@@ -246,10 +246,10 @@ else
 fi
 
 \"\$toolsPath/rclone/rclone\" copy -L \"\$savesPath\" \"\$rclone_provider\":Emudeck/saves -P > \"\$toolsPath/rclone/rclone_job.log\"
-">>"$rclone_jobScript"
-chmod +x "$rclone_jobScript"
+">>"$cloud_backup_jobScript"
+chmod +x "$cloud_backup_jobScript"
 
-echo '#!/bin/bash'>"$rclone_restoreScript"
+echo '#!/bin/bash'>"$cloud_backup_restoreScript"
 echo "source \$HOME/emudeck/settings.sh
 PIDFILE=\"\$toolsPath/rclone/rclone.pid\"
 
@@ -286,8 +286,8 @@ else
 fi
 
 \"\$toolsPath/rclone/rclone\" copy -L \"\$rclone_provider\":Emudeck/saves \"\$savesPath\" -P > \"\$toolsPath/rclone/rclone_job.log\"
-">>"$rclone_restoreScript"
-chmod +x "$rclone_restoreScript"
+">>"$cloud_backup_restoreScript"
+chmod +x "$cloud_backup_restoreScript"
 }
 
 cloud_backup_createService(){
@@ -301,7 +301,7 @@ Description=EmuDeck cloud_backup service
 
 [Service]
 Type=simple
-ExecStart=\"$rclone_jobScript\"
+ExecStart=\"$cloud_backup_jobScript\"
 CPUWeight=20
 CPUQuota=50%
 IOWeight=20

--- a/functions/ToolScripts/emuDeckCloudBackup.sh
+++ b/functions/ToolScripts/emuDeckCloudBackup.sh
@@ -195,13 +195,13 @@ cloud_backup_setup(){
         if [ "$rc" == 0 ] || [ "$ans" == "" ]; then
             break
         elif [ "$ans" == "Install cloud_backup" ] || [ "$ans" == "Reinstall cloud_backup" ]; then
-            rclone_install
+            cloud_backup_install
         elif [ "$ans" == "Pick Provider" ]; then
-            rclone_pickProvider
+            cloud_backup_pickProvider
         elif [ "$ans" == "Login to your cloud provider" ]; then
-            rclone_updateProvider
+            cloud_backup_updateProvider
         elif [ "$ans" == "Create Backup" ]; then
-            rclone_createBackup
+            cloud_backup_createBackup
         fi
     done
 

--- a/functions/ToolScripts/emuDeckCloudBackup.sh
+++ b/functions/ToolScripts/emuDeckCloudBackup.sh
@@ -166,7 +166,7 @@ cloud_backup_providersSetup(){
   fi
 }
 
-cloud_backup_etup(){
+cloud_backup_setup(){
 
     while true; do
         if [ ! -e "$rclone_bin" ] || [ ! -e "$rclone_jobScript" ];  then

--- a/functions/ToolScripts/emuDeckCloudBackup.sh
+++ b/functions/ToolScripts/emuDeckCloudBackup.sh
@@ -166,6 +166,11 @@ cloud_backup_providersSetup(){
   fi
 }
 
+# Previous entry point simply calls new entry point, ensures previously created .desktop shortcuts continue working
+rclone_setup(){
+  cloud_backup_setup
+}
+
 cloud_backup_setup(){
 
     while true; do


### PR DESCRIPTION
A number of months ago the rclone backup script was changed as it was being replaced with the cloud sync feature. This change and new feature was early access only. Now that EmuDeck 2.2 has been released the rclone backup script changes have broken for existing users and the new cloud sync feature is still behind early access leaving some of us without any way of backing up our saves.

This pull request fixes a number of issues with the rclone backup script (previously renamed to cloud backup).

* fix: typo in function signature
* fix: incomplete rename and references to variables
* fix: references to previously renamed functions
* add: restored the previously renamed `rclone_setup` which is the entry point. Existing users will have a .desktop shortcut that calls into that entry point to start the cloud backup script. This restored entry point simply calls the new `cloud_backup_setup` entrypoint.

Small amount of testing has been done locally on my own steam deck which had a previously setup rclone backup. With these changes it will continue to work.