### PR TITLE
Pegasus: Tweaks and Fixes

### DIFF
--- a/configs/pegasus-frontend/game_dirs.txt
+++ b/configs/pegasus-frontend/game_dirs.txt
@@ -88,7 +88,7 @@
 /run/media/mmcblk0p1/Emulation/roms/megadrivejp
 /run/media/mmcblk0p1/Emulation/roms/megaduck
 /run/media/mmcblk0p1/Emulation/roms/mess
-/run/media/mmcblk0p1/Emulation/roms/model2
+/run/media/mmcblk0p1/Emulation/roms/model2/roms
 /run/media/mmcblk0p1/Emulation/roms/model3
 /run/media/mmcblk0p1/Emulation/roms/moonlight
 /run/media/mmcblk0p1/Emulation/roms/moto
@@ -182,6 +182,7 @@
 /run/media/mmcblk0p1/Emulation/roms/x68000
 /run/media/mmcblk0p1/Emulation/roms/xbox
 /run/media/mmcblk0p1/Emulation/roms/xbox360/roms
+/run/media/mmcblk0p1/Emulation/roms/xbox360/roms/xbla
 /run/media/mmcblk0p1/Emulation/roms/zmachine
 /run/media/mmcblk0p1/Emulation/roms/zx81
 /run/media/mmcblk0p1/Emulation/roms/zxspectrum

--- a/functions/ToolScripts/emuDeckPegasus.sh
+++ b/functions/ToolScripts/emuDeckPegasus.sh
@@ -37,18 +37,68 @@ pegasus_init(){
 	rsync -avhp --mkpath "$EMUDECKGIT/configs/$pegasus_emuPath/" "$pegasus_path/"
 
 	#metadata and paths
-	rsync -r  "$EMUDECKGIT/roms/" "$romsPath"
-	rsync -av -f"+ */" -f"- *"  "$EMUDECKGIT/roms/" "$toolsPath/downloaded_media"
+	rsync -r --exclude='roms' --exclude='pfx' "$EMUDECKGIT/roms/" "$romsPath"
+	rsync -av --exclude='roms' --exclude='pfx' "$EMUDECKGIT/roms/" "$toolsPath/downloaded_media"
 	find $romsPath -type f -name "metadata.txt" -exec sed -i "s|CORESPATH|${RetroArch_cores}|g" {} \;
 	find $romsPath -type f -name "metadata.txt" -exec sed -i "s|/run/media/mmcblk0p1/Emulation|${emulationPath}|g" {} \;
 
-	for systemPath in "$romsPath"/*; do rm -rf "$systemPath/media" &> /dev/null; done
 
-	for systemPath in "$romsPath"/*; do system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/'); mkdir -p "$toolsPath/downloaded_media/$system/covers"; rm -rf "$toolsPath/downloaded_media/$system/box2dfront" ; mkdir -p "$toolsPath/downloaded_media/$system/marquees"; rm -rf "$toolsPath/downloaded_media/$system/wheel" &> /dev/null; rm -rf "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null; mkdir -p "$toolsPath/downloaded_media/$system/screenshots/"; done
 
-	for systemPath in "$romsPath"/*; do system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/'); ln -s "$toolsPath/downloaded_media/$system" "$systemPath/media" &> /dev/null; ln -s "$toolsPath/downloaded_media/$system/covers/" "$toolsPath/downloaded_media/$system/box2dfront" &> /dev/null; ln -s "$toolsPath/downloaded_media/$system/marquees/" "$toolsPath/downloaded_media/$system/wheel" &> /dev/null; ln -s "$toolsPath/downloaded_media/$system/screenshots/" "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null; done
+		for systemPath in "$romsPath"/*; do
+			echo $romsPath
+			if  [[ "$systemPath" == "$romsPath/model2" || "$systemPath" == "$romsPath/xbox360" || "$systemPath" == "$romsPath/wiiu" ]]; then
+				rm -rf "$systemPath/roms/media" &> /dev/null;
+				rm -rf "$romsPath/xbox360/roms/xbla/media" &> /dev/null;
+			else
+				rm -rf "$systemPath/media" &> /dev/null;
+			fi
+		done
 
-	for systemPath in "$romsPath"/*; do rm -rf ".*/" &> /dev/null; done
+		for systemPath in "$romsPath"/*; do
+			if [[ "$systemPath" == "$romsPath/model2" || "$systemPath" == "$romsPath/xbox360" || "$systemPath" == "$romsPath/wiiu" ]]; then
+				system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/')
+				echo $system
+				mkdir -p "$toolsPath/downloaded_media/$system/covers"
+				rm -rf "$toolsPath/downloaded_media/$system/box2dfront"
+				mkdir -p "$toolsPath/downloaded_media/$system/marquees"
+				rm -rf "$toolsPath/downloaded_media/$system/wheel" &> /dev/null
+				rm -rf "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null
+				mkdir -p "$toolsPath/downloaded_media/$system/screenshots/"
+			else
+				system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/')
+				mkdir -p "$toolsPath/downloaded_media/$system/covers"
+				rm -rf "$toolsPath/downloaded_media/$system/box2dfront"
+				mkdir -p "$toolsPath/downloaded_media/$system/marquees"
+				rm -rf "$toolsPath/downloaded_media/$system/wheel" &> /dev/null
+				rm -rf "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null
+				mkdir -p "$toolsPath/downloaded_media/$system/screenshots/"
+			fi
+		done
+
+
+		for systemPath in "$romsPath"/*; do
+			if  [[ "$systemPath" == "$romsPath/model2" || "$systemPath" == "$romsPath/xbox360" || "$systemPath" == "$romsPath/wiiu" ]]; then
+				system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/')
+				ln -s "$toolsPath/downloaded_media/$system" "$systemPath/roms/media" &> /dev/null
+				ln -s "$toolsPath/downloaded_media/$system/covers/" "$toolsPath/downloaded_media/$system/box2dfront" &> /dev/null
+				ln -s "$toolsPath/downloaded_media/$system/marquees/" "$toolsPath/downloaded_media/$system/wheel" &> /dev/null
+				ln -s "$toolsPath/downloaded_media/$system/screenshots/" "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null
+				cp -P "$romsPath/xbox360/roms/media" "$romsPath/xbox360/roms/xbla"
+			else
+				system=$(echo "$systemPath" | sed 's/.*\/\([^\/]*\)\/\?$/\1/')
+				ln -s "$toolsPath/downloaded_media/$system" "$systemPath/media" &> /dev/null
+				ln -s "$toolsPath/downloaded_media/$system/covers/" "$toolsPath/downloaded_media/$system/box2dfront" &> /dev/null
+				ln -s "$toolsPath/downloaded_media/$system/marquees/" "$toolsPath/downloaded_media/$system/wheel" &> /dev/null
+				ln -s "$toolsPath/downloaded_media/$system/screenshots/" "$toolsPath/downloaded_media/$system/screenshot" &> /dev/null
+			fi
+		done
+
+		for systemPath in "$romsPath"/*; do
+			rm -rf ".*/" &> /dev/null;
+		done
+
+
+
 
 	sed -i "s|/run/media/mmcblk0p1/Emulation|${emulationPath}|g" "$pegasus_dir_file"
 	mkdir -p "$toolsPath/launchers/pegasus/"

--- a/roms/arcade/metadata.txt
+++ b/roms/arcade/metadata.txt
@@ -1,4 +1,4 @@
 collection: Arcade
 shortname: arcade
 extensions: cmd, CMD, 7z, 7Z, zip, ZIP
-launch: /run/media/mmcblk0p1/Emulation/tools/launchers/retroarch.sh -L CORESPATH/mame_libretro.so {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh {file.path}

--- a/roms/atarijaguar/metadata.txt
+++ b/roms/atarijaguar/metadata.txt
@@ -1,4 +1,4 @@
 collection: Atari Jaguar
 shortname: atarijaguar
 extensions: j64, J64, jag, JAG, rom, ROM, abs, ABS, cof, COF, bin, BIN, prg, PRG, 7z, 7Z, zip, ZIP
-launch: /run/media/mmcblk0p1/Emulation/tools/launchers/retroarch.sh -L CORESPATH/virtualjaguar_libretro.so {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh {file.path}

--- a/roms/atarijaguarcd/metadata.txt
+++ b/roms/atarijaguarcd/metadata.txt
@@ -1,6 +1,6 @@
 collection: Atari Jaguar CD
 shortname: atarijaguarcd
 extensions: j64, J64, jag, JAG, rom, ROM, abs, ABS, cof, COF, bin, BIN, prg, PRG, 7z, 7Z, zip, ZIP
-launch: /run/media/mmcblk0p1/Emulation/tools/launchers/retroarch.sh -L CORESPATH/virtualjaguar_libretro.so {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh {file.path}
 
 

--- a/roms/gc/metadata.txt
+++ b/roms/gc/metadata.txt
@@ -1,6 +1,6 @@
 collection: Nintendo GameCube
 shortname: gc
 extensions: gcm, GCM, iso, ISO, wbfs, WBFS, wia, WIA, ciso, CISO, gcz, GCZ, elf, ELF, dol, DOL, dff, DFF, json, JSON, rvz, RVZ, tgc, TGC, wad, WAD, m3u, M3U
-launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh vblank_mode=0 %command% -b -e {file.path}
+launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh -b -e {file.path}
 
 

--- a/roms/model2/metadata.txt
+++ b/roms/model2/metadata.txt
@@ -1,6 +1,0 @@
-collection: Sega Model 2
-shortname: model2
-extensions: 7z, 7Z, zip, ZIP
-launch: PLACEHOLDER {file.path}
-
-

--- a/roms/model2/roms/metadata.txt
+++ b/roms/model2/roms/metadata.txt
@@ -1,0 +1,6 @@
+collection: Sega Model 2
+shortname: model2
+extensions: zip, ZIP
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/model-2-emulator.sh {file.basename}
+
+

--- a/roms/model3/metadata.txt
+++ b/roms/model3/metadata.txt
@@ -1,6 +1,6 @@
 collection: Sega Model 3
 shortname: model3
-extensions: 7z, 7Z, zip, ZIP
-launch: PLACEHOLDER {file.path}
+extensions: zip, ZIP
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/supermodel.sh {file.path}
 
 

--- a/roms/n64dd/metadata.txt
+++ b/roms/n64dd/metadata.txt
@@ -1,7 +1,7 @@
 collection: Nintendo 64DD
 shortname: n64dd
 extensions: bin, BIN, n64, N64, ndd, NDD, u1, U1, v64, V64, z64, Z64, 7z, 7Z, zip, ZIP
-launch: /run/media/mmcblk0p1/Emulation/tools/launchers/retroarch.sh -L CORESPATH/parallel_n64_libretro.so {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/rosaliesmupengui.sh --fullscreen --nogui --quit-after-emulation {file.path}
 
 
 

--- a/roms/nds/metadata.txt
+++ b/roms/nds/metadata.txt
@@ -1,4 +1,4 @@
 collection: Nintendo DS
 shortname: nds
 extensions: bin, BIN, nds, NDS, 7z, 7Z, zip, ZIP
-launch: /run/media/mmcblk0p1/Emulation/tools/launchers/melonds.sh -f {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/retroarch.sh -L CORESPATH/melondsds_libretro.so {file.path}

--- a/roms/ps3/metadata.txt
+++ b/roms/ps3/metadata.txt
@@ -1,7 +1,7 @@
 collection: Sony PlayStation 3
 shortname: ps3
-extensions: desktop, ps3, PS3, ps3dir, PS3DIR
-launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh --no-gui {file.path}
+extensions: desktop, DESKTOP
+launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh {file.path}
 
 
 

--- a/roms/psp/metadata.txt
+++ b/roms/psp/metadata.txt
@@ -1,7 +1,7 @@
 collection: Sony PlayStation Portable
 shortname: psp
 extensions: elf, ELF, iso, ISO, cso, CSO, prx, PRX, pbp, PBP
-launch: /run/media/mmcblk0p1/Emulation/tools/launchers/retroarch.sh -L CORESPATH/ppsspp_libretro.so {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/ppsspp.sh {file.path}
 
 
 

--- a/roms/switch/metadata.txt
+++ b/roms/switch/metadata.txt
@@ -1,4 +1,4 @@
 collection: Nintendo Switch
 shortname: switch
-extensions: nca, NCA, nro, NRO, nso, NSO, nsp, NSP, xci, XCI, 7z, 7Z, zip, ZIP
-launch: /bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/yuzu.sh -f -g '{file.path}'
+extensions: nca, NCA, nro, NRO, nso, NSO, nsp, NSP, xci, XCI
+launch: /bin/bash /run/media/mmcblk0p1/Emulation/tools/launchers/ryujinx.sh --fullscreen '{file.path}'

--- a/roms/vsmile/metadata.txt
+++ b/roms/vsmile/metadata.txt
@@ -1,6 +1,6 @@
 collection: VTech V, Smile
 shortname: vsmile
 extensions: bin, BIN, 7z, 7Z, zip, ZIP
-launch: PLACEHOLDER {file.path}
+launch: /run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh vsmile -cart {file.path}
 
 

--- a/roms/wii/metadata.txt
+++ b/roms/wii/metadata.txt
@@ -1,4 +1,4 @@
 collection: Nintendo Wii
 shortname: wii
 extensions: gcm, GCM, iso, ISO, wbfs, WBFS, wia, WIA, ciso, CISO, gcz, GCZ, elf, ELF, dol, DOL, dff, DFF, json, JSON, rvz, RVZ, tgc, TGC, wad, WAD, m3u, M3U
-launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh vblank_mode=0 %command% -b -e {file.path}
+launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh -b -e {file.path}

--- a/roms/wiiu/roms/metadata.txt
+++ b/roms/wiiu/roms/metadata.txt
@@ -1,6 +1,6 @@
 collection: Nintendo Wii U
 shortname: wiiu
 extensions: rpx, RPX, wud, WUD, wux, WUX, elf, ELF, iso, ISO, wad, WAD, wua, WUA
-launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh -f -g z:{file.path}
+launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh -f -g {file.path}
 
 

--- a/roms/xbox360/roms/metadata.txt
+++ b/roms/xbox360/roms/metadata.txt
@@ -1,4 +1,4 @@
 collection: Microsoft Xbox 360
 shortname: xbox360
-extensions: iso, ISO, xex, XEX
+extensions: iso, ISO, xex, XEX, zar, ZAR
 launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh "Z:{file.path}"

--- a/roms/xbox360/xbla/metadata.txt
+++ b/roms/xbox360/xbla/metadata.txt
@@ -1,0 +1,4 @@
+collection: Microsoft Xbox 360
+shortname: xbox360
+extensions: iso, ISO, xex, XEX, zar, ZAR
+launch:  /run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh "Z:{file.path}"

--- a/tools/launchers/rpcs3.sh
+++ b/tools/launchers/rpcs3.sh
@@ -5,10 +5,6 @@ rm -rf "$savesPath/.gaming"
 emuName="rpcs3" #parameterize me
 emufolder="$HOME/Applications" # has to be applications for ES-DE to find it
 
-# Works with both Flatpak and AppImage
-export LD_LIBRARY_PATH=/usr/lib:/usr/local/lib
-
-
 #find full path to emu executable
 exe=$(find $emufolder -iname "${emuName}*.AppImage" | sort -n | cut -d' ' -f 2- | tail -n 1 2>/dev/null)
 
@@ -24,11 +20,20 @@ else
     chmod +x $exe
 fi
 
-#run the executable with the params.
-#Fix first '
-param="${@}"
-substituteWith='"'
-param=${param/\'/"$substituteWith"}
-#Fix last ' on command
-param=$(echo "$param" | sed 's/.$/"/')
-eval "${exe} ${param}"
+fileExtension="${@##*.}"
+
+if [[ $fileExtension == "desktop" ]]; then
+    rpcs3desktopFile=$(grep -E "^Exec=" "${*}" | sed 's/^Exec=//' | sed 's/%%/%/g')
+    echo "Exec=$rpcs3desktopFile"
+    eval $rpcs3desktopFile
+else
+    #run the executable with the params.
+    #Fix first '
+    param="${@}"
+    substituteWith='"'
+    param=${param/\'/"$substituteWith"}
+    #Fix last ' on command
+    param=$(echo "$param" | sed 's/.$/"/')
+    eval "${exe} ${param}"
+fi
+


### PR DESCRIPTION
* Fixed Model 2 Emulator and Supermodel metadata files
* Moved metadata files and metadata to rom subfolder for Proton emulators
* Added RPCS3 support through desktop files
* Adjusted defaults 
   * Atari Jaguar/Atari Jaguar CD changed to BigPEmu 
   * Arcade changed to MAME (standalone) 
   * NDS changed to melonDS DS 
   * Nintendo 64DD changed to RMG 
   * PSP changed to PPSSPP (Standalone) 
   * Nintendo Switch changed to Ryujinx (Standalone) 
   * VSmile changed to MAME (Standalone)
* Removed z: from wiiu metadata file since it's presumably running Cemu Native