### PR TITLE
RPCS3: Tweaks and Fixes

### DIFF
--- a/configs/rpcs3/GuiConfigs/CurrentSettings.ini
+++ b/configs/rpcs3/GuiConfigs/CurrentSettings.ini
@@ -48,6 +48,10 @@ enableUIColors=false
 showDebugTab=false
 useRichPresence=true
 
+[PadNavigation]
+allow_global_pad_input=true
+pad_input_enabled=true
+
 [PadSettings]
 geometry=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0~\0\0\0\0\0\0\x4m\0\0\x3\x1f\0\0\0~\0\0\0\x1d\0\0\x4m\0\0\x3\x1f\0\0\0\0\0\0\0\0\x5\0\0\0\0~\0\0\0\x1d\0\0\x4m\0\0\x3\x1f)
 

--- a/configs/rpcs3/config.yml
+++ b/configs/rpcs3/config.yml
@@ -36,7 +36,7 @@ Core:
   XFloat Accuracy: Approximate
   Accurate PPU 128-byte Reservation Op Max Length: 0
   Stub PPU Traps: 0
-  Full Width AVX-512: false
+  Full Width AVX-512: true
   PPU LLVM Java Mode Handling: true
   Use Accurate DFMA: true
   PPU Set Saturation Bit: false
@@ -223,7 +223,7 @@ Miscellaneous:
   Automatically start games after boot: true
   Exit RPCS3 when process finishes: false
   Pause emulation on RPCS3 focus loss: false
-  Start games in fullscreen mode: true
+  Start games in fullscreen mode: false
   Prevent display sleep while running games: true
   Show trophy popups: true
   Show shader compilation hint: true

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-pkg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps3-rpcs3-pkg.json
@@ -34,7 +34,7 @@
     "glob-regex": "${/(^[NP].+)/}/USRDIR/@(eboot.bin|EBOOT.BIN)"
   },
   "titleFromVariable": {
-    "limitToGroups": "${PS3}",
+    "limitToGroups": "${PSN}",
     "caseInsensitiveVariables": false,
     "skipFileIfVariableWasNotFound": false,
     "tryToMatchTitle": true

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -6606,7 +6606,7 @@
       "glob-regex": "${/(^[NP].+)/}/USRDIR/@(eboot.bin|EBOOT.BIN)"
     },
     "titleFromVariable": {
-      "limitToGroups": "${PS3}",
+      "limitToGroups": "${PSN}",
       "caseInsensitiveVariables": false,
       "skipFileIfVariableWasNotFound": false,
       "tryToMatchTitle": true


### PR DESCRIPTION
* Steam ROM Manager: Hotfix RPCS3 Parser
    * Corrected custom variable, fixes installed PKGs not parsing
* Set fullscreen mode to false, seems to be broken at the moment on OLED Steam Decks
* Set Full Width AVX-512 to true, should be on by default (RPCS3 will automatically detect if it can use this setting or not)
* Set gamepad configs to true