### PR TITLE
Steam ROM Manager: Custom Variables + Supermodel Parser 

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -5869,10 +5869,10 @@
       "glob": "**/${title}@(.zip|.ZIP)"
     },
     "titleFromVariable": {
-      "limitToGroups": "",
+      "limitToGroups": "${MAME}",
       "caseInsensitiveVariables": false,
       "skipFileIfVariableWasNotFound": false,
-      "tryToMatchTitle": false
+      "tryToMatchTitle": true
     },
     "fuzzyMatch": {
       "replaceDiacritics": true,
@@ -6098,7 +6098,7 @@
       "shortcutPassthrough": false,
       "appendArgsToExecutable": true
     },
-    "parserId": "164785645253672240",
+    "parserId": "164795646253672241",
     "version": 10,
     "imageProviderAPIs": {
       "SteamGridDB": {

--- a/functions/ToolScripts/emuDeckSRM.sh
+++ b/functions/ToolScripts/emuDeckSRM.sh
@@ -5,6 +5,7 @@ SRM_toolType="$emuDeckEmuTypeAppImage"
 SRM_toolPath="${toolsPath}/Steam ROM Manager.AppImage"
 SRM_userData_directory="configs/steam-rom-manager/userData"
 SRM_userData_configDir="$HOME/.config/steam-rom-manager/userData"
+SRM_customVariablesURL="https://raw.githubusercontent.com/SteamGridDB/steam-rom-manager/master/files/customVariables.json"
 #cleanupOlderThings
 
 SRM_install(){
@@ -92,6 +93,8 @@ SRM_init(){
   sed -i "s|/home/deck|$HOME|g" "$HOME/.config/steam-rom-manager/userData/userSettings.json"
   sed -i "s|/run/media/mmcblk0p1/Emulation/roms|${romsPath}|g" "$HOME/.config/steam-rom-manager/userData/userSettings.json"
   sed -i "s|/run/media/mmcblk0p1/Emulation/tools|${toolsPath}|g" "$HOME/.config/steam-rom-manager/userData/userSettings.json"
+
+  curl -L "$SRM_customVariablesURL" -o "$HOME/.config/steam-rom-manager/userData/customVariables.json"
 
   if [ -d "${HOME}/.local/share/Steam" ]; then
     STEAMPATH="${HOME}/.local/share/Steam"


### PR DESCRIPTION
* Added a line to fetch latest custom variables file
    * Steam ROM Manager recently updated to use PSN instead of PS3 for RPCS3, adding this line allows EmuDeck to grab the latest changes
* Fixed fuzzy matching on Supermodel by adding MAME variable