### PR TITLE
Cloud Backup/Sync: fixed silent failures

### DIFF
--- a/functions/ToolScripts/emuDeckCloudSync.sh
+++ b/functions/ToolScripts/emuDeckCloudSync.sh
@@ -293,7 +293,7 @@ cloud_sync_upload(){
 }
 
 cloud_sync_download(){
-	local branch=$("cd $HOME/.config/EmuDeck/backend && git rev-parse --abbrev-ref HEAD")
+	local branch=$(cd $HOME/.config/EmuDeck/backend && git rev-parse --abbrev-ref HEAD)
 	if [ "$branch" == "early" ] || [ "$branch" == "dev" ] ; then
 		echo "CloudSync Downloading"
 	else


### PR DESCRIPTION
The quoting in this subshell was causing issues with the $HOME substitution, which would result in method failing and returning a non-zero result, which would cause the `emulatorInit` body to fail to run `cloud_sync_startService` (since it was using `&&` to run subsequent commands), which meant the syncing/backing up service was completely down.

**How to test**
With a reasonably working setup on the main branch, try launching an emulated game, play for a bit and then save and exit. Log into your cloud provider of choice and notice that the save has not been updated. Additionally verify this by checking the `$HOME/emudeck/logs/CloudWatcher.log` log file has not been updated.
Apply the changes here and relaunch a game, save and exit. Verify that the cloud copy of the save has been updated and the log file contains information from the watcher.