### PR TITLE
appImageInit: Fix SRM migration

### DIFF
--- a/functions/ToolScripts/emuDeckSRM.sh
+++ b/functions/ToolScripts/emuDeckSRM.sh
@@ -41,12 +41,8 @@ SRM_migration(){
 
     mv "${toolsPath}/srm/Steam-ROM-Manager.AppImage" "${toolsPath}/Steam ROM Manager.AppImage" &> /dev/null
     SRM_customDesktopShortcut
+    SRM_flushToolLauncher
 
-	  SRM_init
-
-	  Citra_resetConfig
-	  PCSX2QT_resetConfig
-	  DuckStation_resetConfig
   fi
 }
 

--- a/functions/appImageInit.sh
+++ b/functions/appImageInit.sh
@@ -17,11 +17,6 @@ appImageInit() {
 	autofix_duplicateESDE
 	autofix_lnk
 	SRM_migration # 2.2 Changes
-	ESDE_migration # 2.2 Changes
-	autofix_dynamicParsers # 2.2 Changes
-
-	#Force SRM appimage move in case the migration fails
-	mv "${toolsPath}/srm/Steam-ROM-Manager.AppImage" "${toolsPath}/Steam ROM Manager.AppImage" &> /dev/null
 
 	if [ -d "$HOME/.config/pegasus-frontend/config" ]; then
 	  rsync -avz $HOME/.config/pegasus-frontend/config/  $HOME/.config/pegasus-frontend/


### PR DESCRIPTION
* Used to reset Steam ROM Manager, PCSX2, DuckStation, and Citra on launch (if users had the old SRM AppImage)