### PR TITLE
checkBIOS: Detect Ryujinx instead of Yuzu

### DIFF
--- a/functions/checkBIOS.sh
+++ b/functions/checkBIOS.sh
@@ -66,9 +66,10 @@ checkPS2BIOS(){
 }
 
 checkYuzuBios(){
-	
-	FILE="$HOME/.local/share/yuzu/keys/prod.keys"
-	if [ -f "$FILE" ]; then	
+
+	RYUJINXFIRMWARE="$HOME/.config/Ryujinx/bis/system/Contents/registered"
+	RYUJINXKEYS="$HOME/.config/Ryujinx/system/prod.keys"
+	if [[ -f "$RYUJINXKEYS" ]] && [[ "$( ls -A "$RYUJINXFIRMWARE")" ]]; then	
 			echo "true";
 	else
 			echo "false";


### PR DESCRIPTION
* BIOS Checker now checks for the presence of both Ryujinx keys and firmware instead of checking for Yuzu keys
* If both keys and firmware are not in place (if one is missing), checker will fail

Wasn't sure if I should update the function name since that's what the app is looking for. 