### PR TITLE
Steam Input Profile Tweaks

### DIFF
--- a/configs/steam-input/emudeck_controller_generic.vdf
+++ b/configs/steam-input/emudeck_controller_generic.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_ps4.vdf
+++ b/configs/steam-input/emudeck_controller_ps4.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_ps5.vdf
+++ b/configs/steam-input/emudeck_controller_ps5.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_ps5_dualsense_edge.vdf
+++ b/configs/steam-input/emudeck_controller_ps5_dualsense_edge.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_steamdeck.vdf
+++ b/configs/steam-input/emudeck_controller_steamdeck.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_steamdeck_radial_menus.vdf
+++ b/configs/steam-input/emudeck_controller_steamdeck_radial_menus.vdf
@@ -8803,8 +8803,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button START, Quick Menu, EmuDeck_Menu.png, "
-							"binding"		"xinput_button JOYSTICK_LEFT, Quick Menu, EmuDeck_Menu.png, "
+							"binding"		"xinput_button SELECT, Quick Menu, EmuDeck_Menu.png, "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Quick Menu, EmuDeck_Menu.png, "
 						}
 						"settings"
 						{
@@ -9029,7 +9029,6 @@
 		"settings"
 		{
 			"touch_menu_opacity"		"100"
-			"touch_menu_scale"		"120"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_switch_pro.vdf
+++ b/configs/steam-input/emudeck_controller_switch_pro.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_xbox360.vdf
+++ b/configs/steam-input/emudeck_controller_xbox360.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_controller_xboxone.vdf
+++ b/configs/steam-input/emudeck_controller_xboxone.vdf
@@ -432,6 +432,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -538,6 +539,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"

--- a/configs/steam-input/emudeck_frontend_controller_generic.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_generic.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_ps4.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps4.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_ps5.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps5.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_ps5_dualsense_edge.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps5_dualsense_edge.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_steamdeck.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_steamdeck.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_switch_pro.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_switch_pro.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_xbox360.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xbox360.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_xboxone.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xboxone.vdf
@@ -303,6 +303,10 @@
 				}
 			}
 		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
+		}
 	}
 	"group"
 	{
@@ -328,6 +332,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -791,6 +799,7 @@
 		"settings"
 		{
 			"deadzone_inner_radius"		"7199"
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -897,6 +906,10 @@
 				{
 				}
 			}
+		}
+		"settings"
+		{
+			"deadzone_enable_type"		"1"
 		}
 	}
 	"group"
@@ -1135,6 +1148,70 @@
 						"bindings"
 						{
 							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_right_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"controller_action empty_binding, , "
 						}
 					}
 				}


### PR DESCRIPTION
* Set deadzone to default (was accidentally turned off previously)
* Set L4/R4 and L5/R5 to blank on the all profile 
   * Seems to be a Steam Input bug so set these to be cleared from parent to prevent any misinputs
* Fixed PCSX2 quick menu hotkey in the radial profile