### PR TITLE
Flycast: Hotfix arcade controls + add default mapping

### DIFF
--- a/configs/org.flycast.Flycast/config/flycast/mappings/SDL_controller_neptune.cfg
+++ b/configs/org.flycast.Flycast/config/flycast/mappings/SDL_controller_neptune.cfg
@@ -1,0 +1,34 @@
+[analog]
+bind0 = 0-:btn_analog_left
+bind1 = 0+:btn_analog_right
+bind2 = 1-:btn_analog_up
+bind3 = 1+:btn_analog_down
+bind4 = 2+:btn_trigger_left
+bind5 = 3-:axis2_left
+bind6 = 3+:axis2_right
+bind7 = 4-:axis2_up
+bind8 = 4+:axis2_down
+bind9 = 5+:btn_trigger_right
+
+[digital]
+bind0 = 0:btn_a
+bind1 = 1:btn_b
+bind10 = 256:btn_dpad1_up
+bind11 = 257:btn_dpad1_down
+bind12 = 258:btn_dpad1_left
+bind13 = 259:btn_dpad1_right
+bind2 = 2:btn_x
+bind3 = 3:btn_y
+bind4 = 4:btn_z
+bind5 = 5:btn_c
+bind6 = 6:btn_menu
+bind7 = 7:btn_start
+bind8 = 8:btn_dpad2_up
+
+[emulator]
+dead_zone = 10
+mapping_name = controller_neptune
+rumble_power = 100
+saturation = 100
+version = 3
+

--- a/configs/org.flycast.Flycast/config/flycast/mappings/SDL_controller_neptune_arcade.cfg
+++ b/configs/org.flycast.Flycast/config/flycast/mappings/SDL_controller_neptune_arcade.cfg
@@ -1,0 +1,35 @@
+[analog]
+bind0 = 0-:btn_analog_left
+bind1 = 0+:btn_analog_right
+bind2 = 1-:btn_analog_up
+bind3 = 1+:btn_analog_down
+bind4 = 2+:btn_trigger_left
+bind5 = 3-:axis2_left
+bind6 = 3+:axis2_right
+bind7 = 4-:axis2_up
+bind8 = 4+:axis2_down
+bind9 = 5+:btn_trigger_right
+
+[digital]
+bind0 = 0:btn_a
+bind1 = 1:btn_b
+bind10 = 256:btn_dpad1_up
+bind11 = 257:btn_dpad1_down
+bind12 = 258:btn_dpad1_left
+bind13 = 259:btn_dpad1_right
+bind2 = 2:btn_x
+bind3 = 3:btn_y
+bind4 = 4:btn_z
+bind5 = 5:btn_c
+bind6 = 6:btn_d
+bind7 = 7:btn_start
+bind8 = 8:btn_dpad2_up
+bind9 = 10:insert_card
+
+[emulator]
+dead_zone = 10
+mapping_name = controller_neptune
+rumble_power = 100
+saturation = 100
+version = 3
+


### PR DESCRIPTION
* Removed select as quick menu for arcade games (still works on Dreamcast games)
* Set coin to select for arcade games
* Added default mapping for dreamcast games 
     * controller_neptune is what the Steam Deck uses for Flycast even though the emulator seems to expose various other similar sounding options