### PR TITLE
Hotfix Steam Input Profiles

### DIFF
--- a/configs/steam-input/emudeck_controller_generic.vdf
+++ b/configs/steam-input/emudeck_controller_generic.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_ps4.vdf
+++ b/configs/steam-input/emudeck_controller_ps4.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_ps5.vdf
+++ b/configs/steam-input/emudeck_controller_ps5.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_ps5_dualsense_edge.vdf
+++ b/configs/steam-input/emudeck_controller_ps5_dualsense_edge.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,20 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - Left Back Button Stop Emulation - Long Press Left Back Button, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - Left Back Button Stop Emulation - Long Press Left Back Button, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press LEFT_ALT, , "
-							"binding"		"key_press F4, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"1000"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -916,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - Right Back Button Toggle Full Screen - Long Press Right Back Button, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_steamdeck.vdf
+++ b/configs/steam-input/emudeck_controller_steamdeck.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_switch_pro.vdf
+++ b/configs/steam-input/emudeck_controller_switch_pro.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_xbox360.vdf
+++ b/configs/steam-input/emudeck_controller_xbox360.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_controller_xboxone.vdf
+++ b/configs/steam-input/emudeck_controller_xboxone.vdf
@@ -292,7 +292,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -308,7 +320,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -520,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -829,8 +852,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -858,8 +881,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -887,18 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -914,18 +926,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_generic.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_generic.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_ps4.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps4.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_ps5.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps5.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_ps5_dualsense_edge.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps5_dualsense_edge.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1371,7 +1394,7 @@
 				{
 				}
 			}
-			"button_back_left_upper"
+			"button_back_left"
 			{
 				"activators"
 				{
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - Left Back Button Stop Emulation - Long Press Left Back Button, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - Left Back Button Stop Emulation - Long Press Left Back Button, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1400,6 +1423,51 @@
 				{
 				}
 			}
+			"button_back_right"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+						}
+					}
+					"Long_Press"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_ALT, , "
+							"binding"		"key_press F4, , "
+						}
+						"settings"
+						{
+							"long_press_time"		"1000"
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
+			"button_back_left_upper"
+			{
+				"activators"
+				{
+					"Full_Press"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
+						}
+					}
+				}
+				"disabled_activators"
+				{
+				}
+			}
 			"button_back_right_upper"
 			{
 				"activators"
@@ -1408,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - Right Back Button Toggle Full Screen - Long Press Right Back Button, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_steamdeck.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_steamdeck.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_switch_pro.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_switch_pro.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_xbox360.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xbox360.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}

--- a/configs/steam-input/emudeck_frontend_controller_xboxone.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xboxone.vdf
@@ -294,7 +294,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Full Screen Toggle, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
 						}
 					}
 				}
@@ -658,7 +658,19 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button X, , "
+							"binding"		"xinput_button X, Swap Screens - Select + X, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press LEFT_CONTROL, , "
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -674,7 +686,18 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button Y, , "
+							"binding"		"xinput_button Y, Toggle Screen Layout - Select + Y, , "
+						}
+					}
+					"chord"
+					{
+						"bindings"
+						{
+							"binding"		"key_press TAB, , "
+						}
+						"settings"
+						{
+							"chord_button"		"15"
 						}
 					}
 				}
@@ -887,7 +910,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Full Screen Toggle - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
 						}
 					}
 					"chord"
@@ -1379,8 +1402,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
-							"binding"		"key_press TAB, Toggle Screen Layout - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
+							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press L5, , "
 						}
 					}
 					"Long_Press"
@@ -1408,8 +1431,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press LEFT_CONTROL, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
-							"binding"		"key_press TAB, Swap Screens - L5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
+							"binding"		"key_press TAB, Swap Screens - R5 / Stop Emulation - Long Press R5, , "
 						}
 					}
 					"Long_Press"
@@ -1437,18 +1460,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - L4 / Toggle Full Screen - Long Press L4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - L4, , "
 						}
 					}
 				}
@@ -1464,18 +1476,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press TAB, Swap Screens - R4 / Toggle Full Screen - Long Press R4, , "
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"key_press F11, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"500"
+							"binding"		"key_press TAB, Toggle Screen Layout - R4, , "
 						}
 					}
 				}


### PR DESCRIPTION
* Removed F11 from R4/L4, these were used for both toggle screen layout and toggle full screen which conflict with each other (if you toggle your screen, you end up toggling full screen at the same time).
* Added Toggle Screen Layout to Select + Y
* Added Swap Screens to Select + X
* Cleaned up hotkey wording