### PR TITLE
Flycast: Hotfixes

### DIFF
--- a/configs/org.flycast.Flycast/config/flycast/emu.cfg
+++ b/configs/org.flycast.Flycast/config/flycast/emu.cfg
@@ -103,7 +103,7 @@ server =
 OpenGlChecks = no
 
 [window]
-fullscreen = no
+fullscreen = yes
 height = 1180
 left = 280
 maximized = no

--- a/configs/org.flycast.Flycast/config/flycast/mappings/SDL_Keyboard_arcade.cfg
+++ b/configs/org.flycast.Flycast/config/flycast/mappings/SDL_Keyboard_arcade.cfg
@@ -2,9 +2,9 @@
 bind0 = 4:btn_d
 bind1 = 6:btn_b
 bind10 = 27:btn_a
-bind11 = 40:insert_card
+bind11 = 40:btn_fforward
 bind12 = 41:btn_escape
-bind13 = 43:btn_menu
+bind13 = 43:insert_card
 bind14 = 58:btn_jump_state
 bind15 = 59:btn_quick_save
 bind16 = 79:btn_dpad1_right

--- a/functions/EmuScripts/emuDeckFlycast.sh
+++ b/functions/EmuScripts/emuDeckFlycast.sh
@@ -46,7 +46,7 @@ Flycast_setEmulationFolder(){
 	setMSG "Setting $Flycast_emuName Emulation Folder"
 
 	ContentPathSetting='Dreamcast.ContentPath = '
-	changeLine "$ContentPathSetting" "${ContentPathSetting}${romsPath}/dreamcast" "${Flycast_configFile}"
+	changeLine "$ContentPathSetting" "${ContentPathSetting}${romsPath}/dreamcast;${romsPath}/atomiswave;${romsPath}/naomi;${romsPath}/naomi2" "${Flycast_configFile}"
 
 	#Setup symlink for bios
 	mkdir -p "${biosPath}/flycast/"


### PR DESCRIPTION
* Set service key to L3
* Set test key to R3
* Moved insert card key to enter (STEAM + DPad Right)
* Added directories for Atomiswave, NAOMI, and NAOMI 2 to Flycast
* Fixed fullscreen scaling bug (fixes Flycast GUI in game mode)