### PR TITLE
RetroArch MAME cleanups

### DIFF
--- a/configs/pegasus-frontend/game_dirs.txt
+++ b/configs/pegasus-frontend/game_dirs.txt
@@ -78,9 +78,6 @@
 /run/media/mmcblk0p1/Emulation/roms/mame
 /run/media/mmcblk0p1/Emulation/roms/mame-advmame
 /run/media/mmcblk0p1/Emulation/roms/mame-mame4all
-/run/media/mmcblk0p1/Emulation/roms/mame2003
-/run/media/mmcblk0p1/Emulation/roms/mame2010
-/run/media/mmcblk0p1/Emulation/roms/mamecurrent
 /run/media/mmcblk0p1/Emulation/roms/mastersystem
 /run/media/mmcblk0p1/Emulation/roms/megacd
 /run/media/mmcblk0p1/Emulation/roms/megacdjp

--- a/functions/ToolScripts/emuDeckESDE.sh
+++ b/functions/ToolScripts/emuDeckESDE.sh
@@ -129,6 +129,7 @@ ESDE_init(){
 	SRM_createParsers
 	addSteamInputCustomIcons
 	ESDE_flushToolLauncher
+	SRM_flushOldSymlinks
 }
 
 

--- a/functions/ToolScripts/emuDeckPegasus.sh
+++ b/functions/ToolScripts/emuDeckPegasus.sh
@@ -112,6 +112,7 @@ pegasus_init(){
 	pegasus_applyTheme "$pegasusThemeUrl"
 	addSteamInputCustomIcons
 	pegasus_flushToolLauncher
+	SRM_flushOldSymlinks
 
 }
 

--- a/functions/ToolScripts/emuDeckSRM.sh
+++ b/functions/ToolScripts/emuDeckSRM.sh
@@ -105,6 +105,7 @@ SRM_init(){
   SRM_addSteamInputProfiles
   addSteamInputCustomIcons
   SRM_setEnv
+  SRM_flushOldSymlinks
   
   echo -e "true"
 
@@ -526,4 +527,16 @@ SRM_flushToolLauncher(){
   mkdir -p "$toolsPath/launchers/srm"
 	cp "$EMUDECKGIT/tools/launchers/srm/steamrommanager.sh" "$toolsPath/launchers/srm/steamrommanager.sh"
   chmod +x "$toolsPath/launchers/srm/steamrommanager.sh"
+}
+
+SRM_flushOldSymlinks(){
+
+  if [ -L "$romsPath/mame2003" ]; then
+    rm -f "$romsPath/mame2003"
+  fi
+
+  if [ -L "$romsPath/mamecurrent" ]; then
+    rm -f "$romsPath/mamecurrent"
+  fi
+
 }


### PR DESCRIPTION
* Added detection to delete mame2003 and mamecurrent symlinks
* Removed mame2003, mame2010, and mamecurrent from Pegasus configs
* Changed the mame folder to use MAME current through Pegasus