### PR TITLE
Steam ROM Manager: Add delete cache function

### DIFF
--- a/functions/ToolScripts/emuDeckSRM.sh
+++ b/functions/ToolScripts/emuDeckSRM.sh
@@ -540,3 +540,46 @@ SRM_flushOldSymlinks(){
   fi
 
 }
+
+SRM_deleteCache(){
+
+  if [ -d "${HOME}/.local/share/Steam" ]; then
+    STEAMPATH="${HOME}/.local/share/Steam"
+  elif [ -d "${HOME}/.steam/steam" ]; then
+    STEAMPATH="${HOME}/.steam/steam"
+  else
+    echo "Steam install not found"
+  fi
+
+		zenity --question \
+    --text="If you are experiencing freezing or crashing with Steam ROM Manager, this will delete the cache and reset your non-Steam library. \
+    \nThis will delete all of your non-Steam shortcuts. \
+    \nDo note this includes any game launchers, browsers, fan games, any games or applications you have added as a non-Steam game. This will not delete the games or applications themselves. \
+    \n \
+    \nThis will also delete any curated art you may have selected or downloaded for both Steam and non-Steam games. \
+    \n \
+    \nDeleting the cache will remove any launch option modifications for Steam games. \
+    \n \ 
+    \nIf you do not delete the cache, Steam ROM Manager may continue to crash or freeze. However, your non-Steam shortcuts will remain intact. \
+    \n \
+    \nWould you like to delete the cache?" \
+    --title="Delete Cache" \
+		--width=400 \
+		--height=300 \
+    --ok-label="No" \
+    --cancel-label="Yes"
+
+
+		if [ $? = 1 ]; then
+      find "$STEAMPATH/userdata" -mindepth 2 -maxdepth 2 -type d -name 'config' -exec rm -rf {} +
+      echo "Cache deleted."
+      zenity --info \
+      --text="The cache has been deleted. All of your non-Steam shortcuts have been wiped. You may open Steam ROM Manager and re-add your ROMs to your library." \
+      --title="Cache deleted" \
+      --width=400 \
+      --height=300
+    else 
+      echo "User declined deleting cache."
+    fi 
+
+}


### PR DESCRIPTION
* Users were experiencing freezing/crashing with Steam ROM Manager on the new EmuDeck update. This wipe cache function "resets" the non-Steam library and ideally should fix any crashing or freezing.

![image](https://github.com/dragoonDorise/EmuDeck/assets/108900299/7243b0f2-edef-4021-b9e8-5bf8f15bb768)

Requires a "Delete Cache" button to be added to the below page and hooked up to `SRM_deleteCache`

![image](https://github.com/dragoonDorise/EmuDeck/assets/108900299/af49f668-904a-4d5d-b166-efa5e858efe7)
