### PR TITLE
Citra: Hotfix freezing

### DIFF
--- a/configs/org.citra_emu.citra/config/citra-emu/qt-config.ini
+++ b/configs/org.citra_emu.citra/config/citra-emu/qt-config.ini
@@ -175,9 +175,9 @@ use_cpu_jit\default=true
 
 [Data%20Storage]
 nand_directory=/home/deck/.var/app/org.citra_emu.citra/data/citra-emu/nand/
-nand_directory\default=false
+nand_directory\default=true
 sdmc_directory=/home/deck/.var/app/org.citra_emu.citra/data/citra-emu/sdmc/
-sdmc_directory\default=false
+sdmc_directory\default=true
 use_custom_storage=false
 use_custom_storage\default=true
 use_virtual_sd=true
@@ -457,7 +457,7 @@ Paths\language=en
 Paths\language\default=false
 Paths\moviePlaybackPath=
 Paths\movieRecordPath=
-Paths\recentFiles=/home/deck/Emulation/roms/n3ds/Picross 3D - Round 2.3ds, 
+Paths\recentFiles=
 Paths\romsPath=
 Paths\screenshotPath=/home/deck/.var/app/org.citra_emu.citra/data/citra-emu/screenshots/
 Paths\screenshotPath\default=false

--- a/functions/EmuScripts/emuDeckCitra.sh
+++ b/functions/EmuScripts/emuDeckCitra.sh
@@ -74,6 +74,18 @@ Citra_setEmulationFolder(){
 		newGameDirOpt='Paths\\gamedirs\\3\\path='"${romsPath}/n3ds"
 		sed -i "/${gameDirOpt}/c\\${newGameDirOpt}" "$Citra_configFile"
 
+		nandDirOpt='nand_directory='
+		newnandDirOpt='nand_directory='"$HOME/.local/share/citra-emu/nand/"
+		sed -i "/${nandDirOpt}/c\\${newnandDirOpt}" "$Citra_configFile"
+
+		sdmcDirOpt='sdmc_directory='
+		newsdmcDirOpt='sdmc_directory='"$HOME/.local/share/citra-emu/sdmc/"
+		sed -i "/${sdmcDirOpt}/c\\${newsdmcDirOpt}" "$Citra_configFile"
+
+		screenshotsDirOpt='Paths\\screenshotPath='
+		newscreenshotDirOpt='Paths\\screenshotPath='"$HOME/.local/share/citra-emu/screenshots/"
+		sed -i "/${screenshotsDirOpt}/c\\${newscreenshotDirOpt}" "$Citra_configFile"
+
 		#Setup symlink for AES keys
 		mkdir -p "${biosPath}/citra/"
 		mkdir -p "$HOME/.local/share/citra-emu/sysdata"
@@ -88,12 +100,6 @@ Citra_setEmulationFolder(){
 
 		echo "Flatpak found. Setting configurations."
 
-		if [[ -e "$Citra_emuPath" ]] && [[ ! -f "$HOME/.config/EmuDeck/.citrasaves" ]];  then
-			echo "AppImage found. Copying Flatpak saves."
-			mkdir -p "$HOME/.local/share/citra-emu/sdmc"
-			rsync -avhp "$HOME/.var/app/org.citra_emu.citra/data/citra-emu/sdmc/." "$HOME/.local/share/citra-emu/sdmc/."  --ignore-existing
-			touch "$HOME/.config/EmuDeck/.citrasaves"
-		fi
 
 		mkdir -p $Citra_flatpakconfigPath
 		rsync -avhp "$EMUDECKGIT/configs/org.citra_emu.citra/config/citra-emu/qt-config.ini" "$Citra_flatpakconfigPath/qt-config.ini" --backup --suffix=.bak
@@ -108,6 +114,13 @@ Citra_setEmulationFolder(){
 
 	else
 		echo "Flatpak not found."
+	fi
+
+	if [[ -e "$Citra_emuPath" ]] && [[ ! -f "$HOME/.config/EmuDeck/.citracopysaves" ]] && [[ -d "$HOME/.var/app/org.citra_emu.citra/data/citra-emu/sdmc" ]] ;  then
+		echo "AppImage found. Copying Flatpak saves."
+		mkdir -p "$HOME/.local/share/citra-emu/sdmc"
+		rsync -avhp "$HOME/.var/app/org.citra_emu.citra/data/citra-emu/sdmc/." "$HOME/.local/share/citra-emu/sdmc/."  --ignore-existing
+		touch "$HOME/.config/EmuDeck/.citracopysaves"
 	fi
 
 


### PR DESCRIPTION
* Flatpak and AppImage configs were tangled. Added sed commands to redirect AppImage to AppImage paths.