### PR TITLE
ES-DE: Hotfix custom_systems folder not being created

### DIFF
--- a/functions/EmuScripts/emuDeckBigPEmu.sh
+++ b/functions/EmuScripts/emuDeckBigPEmu.sh
@@ -50,6 +50,8 @@ BigPEmu_init(){
 	BigPEmu_flushEmulatorLauncher
 	#SRM_createParsers
 	if [ -e "$ESDE_toolPath" ]; then
+		ESDE_junksettingsFile
+		ESDE_addCustomSystemsFile
 		BigPEmu_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."
@@ -105,6 +107,8 @@ BigPEmu_update(){
 	BigPEmu_setupSaves
 	BigPEmu_flushEmulatorLauncher
 	if [ -e "$ESDE_toolPath" ]; then
+		ESDE_junksettingsFile
+		ESDE_addCustomSystemsFile
 		BigPEmu_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."

--- a/functions/EmuScripts/emuDeckCemu.sh
+++ b/functions/EmuScripts/emuDeckCemu.sh
@@ -241,6 +241,8 @@ Cemu_functions () {
 		flushEmulatorLauncher
 	
 		if [ -e "$ESDE_toolPath" ]; then
+			ESDE_junksettingsFile
+			ESDE_addCustomSystemsFile
 			CemuProton_addESConfig
 		else
 			echo "false"
@@ -262,6 +264,8 @@ Cemu_functions () {
 		addSteamInputProfile
 		flushEmulatorLauncher
 		if [ -e "$ESDE_toolPath" ]; then
+			ESDE_junksettingsFile
+			ESDE_addCustomSystemsFile
 			CemuProton_addESConfig
 		else
 			echo "ES-DE not found. Skipped adding custom system."

--- a/functions/EmuScripts/emuDeckCemuProton.sh
+++ b/functions/EmuScripts/emuDeckCemuProton.sh
@@ -92,6 +92,8 @@ CemuProton_init(){
 	fi
 
 	if [ -e "$ESDE_toolPath" ]; then
+		ESDE_junksettingsFile
+		ESDE_addCustomSystemsFile
 		CemuProton_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."
@@ -108,6 +110,8 @@ CemuProton_update(){
 	CemuProton_addESConfig
 	CemuProton_flushEmulatorLauncher
 	if [ -e "$ESDE_toolPath" ]; then
+		ESDE_junksettingsFile
+		ESDE_addCustomSystemsFile
 		CemuProton_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."

--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -52,6 +52,8 @@ Model2_init(){
 	Model2_flushEmulatorLauncher
 	Model2_addSteamInputProfile
 	if [ -e "$ESDE_toolPath" ]; then
+		ESDE_junksettingsFile
+		ESDE_addCustomSystemsFile
 		Model2_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."

--- a/functions/EmuScripts/emuDeckRyujinx.sh
+++ b/functions/EmuScripts/emuDeckRyujinx.sh
@@ -71,6 +71,8 @@ Ryujinx_init(){
     Ryujinx_flushEmulatorLauncher
 
 	if [ -e "$ESDE_toolPath" ]; then
+        ESDE_junksettingsFile
+        ESDE_addCustomSystemsFile
 		Yuzu_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."
@@ -91,6 +93,8 @@ Ryujinx_update(){
     Ryujinx_flushEmulatorLauncher
 
 	if [ -e "$ESDE_toolPath" ]; then
+        ESDE_junksettingsFile
+        ESDE_addCustomSystemsFile
 		Yuzu_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -71,6 +71,8 @@ Xenia_init(){
 	Xenia_flushEmulatorLauncher
 
 	if [ -e "$ESDE_toolPath" ]; then
+		ESDE_junksettingsFile
+		ESDE_addCustomSystemsFile
 		Xenia_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."

--- a/functions/EmuScripts/emuDeckYuzu.sh
+++ b/functions/EmuScripts/emuDeckYuzu.sh
@@ -98,6 +98,8 @@ Yuzu_init() {
 							"False"
 
 	if [ -e "$ESDE_toolPath" ]; then
+        ESDE_junksettingsFile
+        ESDE_addCustomSystemsFile
 		Yuzu_addESConfig
 	else
 		echo "ES-DE not found. Skipped adding custom system."

--- a/functions/ToolScripts/emuDeckESDE.sh
+++ b/functions/ToolScripts/emuDeckESDE.sh
@@ -108,12 +108,10 @@ ESDE_init(){
 
 	ESDE_migration
 	ESDE_junksettingsFile
-
-	mkdir -p "$ESDE_newConfigDirectory/custom_systems/"
+	ESDE_addCustomSystemsFile
+	
 	mkdir -p "$ESDE_newConfigDirectory/settings"
-
 	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/es_settings.xml" "$(dirname "$es_settingsFile")" --backup --suffix=.bak
-	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --backup --suffix=.bak
 	rsync -avhp --mkpath "$EMUDECKGIT/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml" "$(dirname "$es_rulesFile")" --backup --suffix=.bak
 
 	cp -r "$EMUDECKGIT/tools/launchers/es-de/." "$toolsPath/launchers/es-de/" && chmod +x "$toolsPath/launchers/es-de/es-de.sh"
@@ -147,13 +145,13 @@ ESDE_update(){
 
 	ESDE_migration
 	ESDE_junksettingsFile
+	ESDE_addCustomSystemsFile
 
 	mkdir -p "$ESDE_newConfigDirectory/custom_systems/"
 	mkdir -p "$ESDE_newConfigDirectory/settings"
 
 	#update es_settings.xml
 	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/es_settings.xml" "$(dirname "$es_settingsFile")" --ignore-existing
-	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --ignore-existing
 	rsync -avhp --mkpath "$EMUDECKGIT/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml" "$(dirname "$es_rulesFile")" --ignore-existing
 
 	ESDE_addCustomSystems
@@ -167,17 +165,34 @@ ESDE_update(){
 	ESDE_flushToolLauncher
 }
 
+
 ESDE_junksettingsFile(){
 
-junkSettingsFile="$ESDE_newConfigDirectory/settings"
+	local junkSettingsFile="$ESDE_newConfigDirectory/settings"
+	local customSystemsFile="$ESDE_newConfigDirectory/custom_systems"
 
 	if [ -f "$junkSettingsFile" ]; then
 		rm -f "$junkSettingsFile"
-		echo "'$junkSettingsFile' deleted."
+		echo ""$junkSettingsFile" deleted."
 	else
-		echo "File '$junkSettingsFile' does not exist."
+		echo ""$junkSettingsFile" does not exist."
 	fi
 
+	if [ -f "$customSystemsFile" ]; then
+		rm -f "$customSystemsFile"
+		echo ""$customSystemsFile" deleted."
+	else
+		echo ""$customSystemsFile" does not exist."
+	fi
+
+
+}
+
+ESDE_addCustomSystemsFile(){
+
+	# Separate function so it can be copied and used in the emulator scripts. 
+	mkdir -p "$ESDE_newConfigDirectory/custom_systems/"
+	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --backup --suffix=.bak
 
 }
 

--- a/functions/appImageInit.sh
+++ b/functions/appImageInit.sh
@@ -158,14 +158,48 @@ appImageInit() {
 
 		if [ $? = 0 ]; then
 
-			Yuzu_addESConfig
-
+			if [ -e "$ESDE_toolPath" ]; then
+				ESDE_junksettingsFile
+				ESDE_addCustomSystemsFile
+				Yuzu_addESConfig
+			else
+				echo "ES-DE not found. Skipped adding custom system."
+			fi
+			
 		else 
 			echo "Do not apply hotfix."
 		fi
 	touch "$HOME/.config/EmuDeck/.esdeupdateyuzu"
 	fi
-	
+
+	if [ ! -f "$HOME/.config/EmuDeck/.esdefixupdateyuzu" ] && [ -f "$HOME/ES-DE/custom_systems" ]; then
+
+		zenity --info --text="If you are seeing this pop-up, that means the ES-DE hotfix for Yuzu did not properly apply to your system. Press OK below to proceed to the next pop-up so you may re-apply the hotfix."
+		--title="ES-DE" \
+		--width=400 \
+		--height=300
+		
+		zenity --question \
+		--text="An upcoming ES-DE update will be removing Yuzu support. This means that you will no longer be able to launch Nintendo Switch games using Yuzu in ES-DE. \nHowever, EmuDeck has pushed a hotfix to add back Yuzu support for ES-DE. \nIf you say no to this prompt, you may also apply this fix at any time by resetting ES-DE or Yuzu on the Manage Emulators page. \nWould you like to apply this hotfix?" \
+		--title="ES-DE Update" \
+		--width=400 \
+		--height=300
+
+		if [ $? = 0 ]; then
+
+			if [ -e "$ESDE_toolPath" ]; then
+				ESDE_junksettingsFile
+				ESDE_addCustomSystemsFile
+				Yuzu_addESConfig
+			else
+				echo "ES-DE not found. Skipped adding custom system."
+			fi
+			
+		else 
+			echo "Do not apply hotfix."
+		fi
+	touch "$HOME/.config/EmuDeck/.esdefixupdateyuzu"
+	fi
 
 
 	# Init functions


### PR DESCRIPTION
* If users reset emulator configurations and not ES-DE, a junk custom_systems file would be created. This adds creating the custom_systems folder to emulator scripts when applicable.
* Added a function to ES-DE to delete the junk custom_systems file so legacy users can update and have the custom_systems folder actually generate.