### PR TITLE
ES-DE: Hotfix paths not being set

### DIFF
--- a/functions/EmuScripts/emuDeckBigPEmu.sh
+++ b/functions/EmuScripts/emuDeckBigPEmu.sh
@@ -53,6 +53,7 @@ BigPEmu_init(){
 		ESDE_junksettingsFile
 		ESDE_addCustomSystemsFile
 		BigPEmu_addESConfig
+		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -110,6 +111,7 @@ BigPEmu_update(){
 		ESDE_junksettingsFile
 		ESDE_addCustomSystemsFile
 		BigPEmu_addESConfig
+		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi

--- a/functions/EmuScripts/emuDeckCemu.sh
+++ b/functions/EmuScripts/emuDeckCemu.sh
@@ -244,6 +244,7 @@ Cemu_functions () {
 			ESDE_junksettingsFile
 			ESDE_addCustomSystemsFile
 			CemuProton_addESConfig
+			ESDE_setEmulationFolder
 		else
 			echo "false"
 		fi
@@ -267,6 +268,7 @@ Cemu_functions () {
 			ESDE_junksettingsFile
 			ESDE_addCustomSystemsFile
 			CemuProton_addESConfig
+			ESDE_setEmulationFolder
 		else
 			echo "ES-DE not found. Skipped adding custom system."
 		fi

--- a/functions/EmuScripts/emuDeckCemuProton.sh
+++ b/functions/EmuScripts/emuDeckCemuProton.sh
@@ -95,6 +95,7 @@ CemuProton_init(){
 		ESDE_junksettingsFile
 		ESDE_addCustomSystemsFile
 		CemuProton_addESConfig
+		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -113,6 +114,7 @@ CemuProton_update(){
 		ESDE_junksettingsFile
 		ESDE_addCustomSystemsFile
 		CemuProton_addESConfig
+		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi

--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -55,6 +55,7 @@ Model2_init(){
 		ESDE_junksettingsFile
 		ESDE_addCustomSystemsFile
 		Model2_addESConfig
+		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi

--- a/functions/EmuScripts/emuDeckRyujinx.sh
+++ b/functions/EmuScripts/emuDeckRyujinx.sh
@@ -74,6 +74,7 @@ Ryujinx_init(){
         ESDE_junksettingsFile
         ESDE_addCustomSystemsFile
 		Yuzu_addESConfig
+        ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -96,6 +97,7 @@ Ryujinx_update(){
         ESDE_junksettingsFile
         ESDE_addCustomSystemsFile
 		Yuzu_addESConfig
+        ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -74,6 +74,7 @@ Xenia_init(){
 		ESDE_junksettingsFile
 		ESDE_addCustomSystemsFile
 		Xenia_addESConfig
+		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi

--- a/functions/EmuScripts/emuDeckYuzu.sh
+++ b/functions/EmuScripts/emuDeckYuzu.sh
@@ -101,6 +101,7 @@ Yuzu_init() {
         ESDE_junksettingsFile
         ESDE_addCustomSystemsFile
 		Yuzu_addESConfig
+        ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi


### PR DESCRIPTION
* If users delete their custom systems folder and reset an emulator, it previously would not set the paths correctly. Added ESDE_setEmulationFolder to emulator scripts when applicable.