### PR TITLE
PCSX2: Disable wizard by default

### DIFF
--- a/functions/EmuScripts/emuDeckPCSX2QT.sh
+++ b/functions/EmuScripts/emuDeckPCSX2QT.sh
@@ -68,6 +68,7 @@ PCSX2QT_setEmulationFolder() {
 	setMSG "Setting $PCSX2QT_emuName Emulation Folder"
 
 	iniFieldUpdate "$PCSX2QT_configFile" "UI" "ConfirmShutdown" "false"
+ 	iniFieldUpdate "$PCSX2QT_configFile" "UI" "SetupWizardIncomplete" "false"
 	iniFieldUpdate "$PCSX2QT_configFile" "Folders" "Bios" "${biosPath}"
 	iniFieldUpdate "$PCSX2QT_configFile" "Folders" "Snapshots" "${storagePath}/pcsx2/snaps"
 	iniFieldUpdate "$PCSX2QT_configFile" "Folders" "Savestates" "${savesPath}/pcsx2/states"


### PR DESCRIPTION
Onboarding wizard now shows up on launch (even though EmuDeck already configures everything). This disables the onboarding wizard by default.