### PR TITLE
Dolphin: Hotfix trackpad support in front-ends

### DIFF
--- a/configs/org.DolphinEmu.dolphin-emu/config/dolphin-emu/Profiles/Wiimote/Wii_base_nunchuck_with_touchpad.ini
+++ b/configs/org.DolphinEmu.dolphin-emu/config/dolphin-emu/Profiles/Wiimote/Wii_base_nunchuck_with_touchpad.ini
@@ -1,6 +1,6 @@
 [Profile]
 Device = SDL/0/Steam Virtual Gamepad
-Buttons/A = `Button S`|`Thumb R`
+Buttons/A = `Button S`|`Thumb R`|`XInput2/0/Virtual core pointer:Click 1`
 Buttons/B = `Button E`
 Buttons/1 = `Button N`
 Buttons/2 = `Button W`

--- a/configs/org.DolphinEmu.dolphin-emu/config/dolphin-emu/Profiles/Wiimote/Wii_no_attachment_with_touchpad.ini
+++ b/configs/org.DolphinEmu.dolphin-emu/config/dolphin-emu/Profiles/Wiimote/Wii_no_attachment_with_touchpad.ini
@@ -1,6 +1,6 @@
 [Profile]
 Device = SDL/0/Steam Virtual Gamepad
-Buttons/A = `Button S`|`Thumb R`
+Buttons/A = `Button S`|`Thumb R`|`XInput2/0/Virtual core pointer:Click 1`
 Buttons/B = `Button E`
 Buttons/1 = `Button N`
 Buttons/2 = `Button W`


### PR DESCRIPTION
* Front-ends use the custom EmuDeck Steam Input profile which binds the right trackpad to left click. This PR adds support for left clicking in Wii games.