### PR TITLE
Proton Cleanup

### DIFF
--- a/functions/EmuScripts/emuDeckBigPEmu.sh
+++ b/functions/EmuScripts/emuDeckBigPEmu.sh
@@ -48,19 +48,38 @@ BigPEmu_init(){
 	BigPEmu_setEmulationFolder
 	BigPEmu_setupSaves
 	BigPEmu_flushEmulatorLauncher
+	addProtonLaunch
 	#SRM_createParsers
-	if [ -e "$ESDE_toolPath" ]; then
-		ESDE_junksettingsFile
-		ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		BigPEmu_addESConfig
-		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
 
 }
 
+#update
+BigPEmu_update(){
+	setMSG "Updating $BigPEmu_emuName settings."
+	rsync -avhp "$EMUDECKGIT/configs/bigpemu/" "$BigPEmu_appData" --ignore-existing
+	BigPEmu_setEmulationFolder
+	BigPEmu_setupSaves
+	BigPEmu_flushEmulatorLauncher
+	addProtonLaunch
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
+		BigPEmu_addESConfig
+	else
+		echo "ES-DE not found. Skipped adding custom system."
+	fi
+}
+
 BigPEmu_addESConfig(){
+
+	ESDE_junksettingsFile
+	ESDE_addCustomSystemsFile
+	ESDE_setEmulationFolder
+	
+	# Atari Jaguar
 	if [[ $(grep -rnw "$es_systemsFile" -e 'atarijaguar') == "" ]]; then
 		xmlstarlet ed -S --inplace --subnode '/systemList' --type elem --name 'system' \
 		--var newSystem '$prev' \
@@ -81,6 +100,12 @@ BigPEmu_addESConfig(){
 		-r 'systemList/system/commandM' -v 'command' \
 		"$es_systemsFile"
 
+		#format doc to make it look nice
+		xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
+	fi
+
+	# Atari Jaguar CD
+	if [[ $(grep -rnw "$es_systemsFile" -e 'atarijaguarcd') == "" ]]; then
 		xmlstarlet ed -S --inplace --subnode '/systemList' --type elem --name 'system' \
 		--var newSystem '$prev' \
 		--subnode '$newSystem' --type elem --name 'name' -v 'atarijaguarcd' \
@@ -97,24 +122,9 @@ BigPEmu_addESConfig(){
 		#format doc to make it look nice
 		xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 	fi
-	#Custom Systems config end
-}
 
-#update
-BigPEmu_update(){
-	setMSG "Updating $BigPEmu_emuName settings."
-	rsync -avhp "$EMUDECKGIT/configs/bigpemu/" "$BigPEmu_appData" --ignore-existing
-	BigPEmu_setEmulationFolder
-	BigPEmu_setupSaves
-	BigPEmu_flushEmulatorLauncher
-	if [ -e "$ESDE_toolPath" ]; then
-		ESDE_junksettingsFile
-		ESDE_addCustomSystemsFile
-		BigPEmu_addESConfig
-		ESDE_setEmulationFolder
-	else
-		echo "ES-DE not found. Skipped adding custom system."
-	fi
+
+	#Custom Systems config end
 }
 
 

--- a/functions/EmuScripts/emuDeckCemuProton.sh
+++ b/functions/EmuScripts/emuDeckCemuProton.sh
@@ -80,7 +80,8 @@ CemuProton_init(){
 	#CemuProton_addSteamInputProfile
 	CemuProton_addESConfig
 	CemuProton_flushEmulatorLauncher
-
+	addProtonLaunch
+	
 	if [ -e "${romsPath}/wiiu/controllerProfiles/controller1.xml" ];then
 		mv "${romsPath}/wiiu/controllerProfiles/controller1.xml" "${romsPath}/wiiu/controllerProfiles/controller1.xml.bak"
 	fi
@@ -91,11 +92,8 @@ CemuProton_init(){
 		mv "${romsPath}/wiiu/controllerProfiles/controller3.xml" "${romsPath}/wiiu/controllerProfiles/controller3.xml.bak"
 	fi
 
-	if [ -e "$ESDE_toolPath" ]; then
-		ESDE_junksettingsFile
-		ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		CemuProton_addESConfig
-		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -110,11 +108,8 @@ CemuProton_update(){
 	#CemuProton_addSteamInputProfile
 	CemuProton_addESConfig
 	CemuProton_flushEmulatorLauncher
-	if [ -e "$ESDE_toolPath" ]; then
-		ESDE_junksettingsFile
-		ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		CemuProton_addESConfig
-		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -149,6 +144,10 @@ CemuProton_setLanguage(){
 }
 
 CemuProton_addESConfig(){
+
+	ESDE_junksettingsFile
+	ESDE_addCustomSystemsFile
+	ESDE_setEmulationFolder
 
 	#insert cemu custom system if it doesn't exist, but the file does
 	if [[ $(grep -rnw "$es_systemsFile" -e 'wiiu') == "" ]]; then
@@ -261,8 +260,6 @@ CemuProton_setResolution(){
 }
 
 CemuProton_flushEmulatorLauncher(){
-
-
 	flushEmulatorLaunchers "cemu"
-
 }
+

--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -51,11 +51,8 @@ Model2_init(){
 	#SRM_createParsers
 	Model2_flushEmulatorLauncher
 	Model2_addSteamInputProfile
-	if [ -e "$ESDE_toolPath" ]; then
-		ESDE_junksettingsFile
-		ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		Model2_addESConfig
-		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -65,6 +62,11 @@ Model2_init(){
 
 
 Model2_addESConfig(){
+	
+	ESDE_junksettingsFile
+	ESDE_addCustomSystemsFile
+	ESDE_setEmulationFolder
+
 	if [[ $(grep -rnw "$es_systemsFile" -e 'model2') == "" ]]; then
 		xmlstarlet ed -S --inplace --subnode '/systemList' --type elem --name 'system' \
 		--var newSystem '$prev' \

--- a/functions/EmuScripts/emuDeckRyujinx.sh
+++ b/functions/EmuScripts/emuDeckRyujinx.sh
@@ -70,11 +70,8 @@ Ryujinx_init(){
 	#SRM_createParsers
     Ryujinx_flushEmulatorLauncher
 
-	if [ -e "$ESDE_toolPath" ]; then
-        ESDE_junksettingsFile
-        ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		Yuzu_addESConfig
-        ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -93,11 +90,8 @@ Ryujinx_update(){
     Ryujinx_finalize
     Ryujinx_flushEmulatorLauncher
 
-	if [ -e "$ESDE_toolPath" ]; then
-        ESDE_junksettingsFile
-        ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		Yuzu_addESConfig
-        ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -69,12 +69,10 @@ Xenia_init(){
 	#SRM_createParsers
 	Xenia_cleanESDE
 	Xenia_flushEmulatorLauncher
-
-	if [ -e "$ESDE_toolPath" ]; then
-		ESDE_junksettingsFile
-		ESDE_addCustomSystemsFile
+	addProtonLaunch
+	
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		Xenia_addESConfig
-		ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -82,6 +80,11 @@ Xenia_init(){
 }
 
 Xenia_addESConfig(){
+
+	ESDE_junksettingsFile
+	ESDE_addCustomSystemsFile
+	ESDE_setEmulationFolder
+	
 	if [[ $(grep -rnw "$es_systemsFile" -e 'xbox360') == "" ]]; then
 		xmlstarlet ed -S --inplace --subnode '/systemList' --type elem --name 'system' \
 		--var newSystem '$prev' \
@@ -225,8 +228,6 @@ Xenia_cleanESDE(){
 }
 
 Xenia_flushEmulatorLauncher(){
-
-
 	flushEmulatorLaunchers "xenia"
-
 }
+

--- a/functions/EmuScripts/emuDeckYuzu.sh
+++ b/functions/EmuScripts/emuDeckYuzu.sh
@@ -97,11 +97,8 @@ Yuzu_init() {
 							"${toolsPath}/launchers/yuzu.sh"  \
 							"False"
 
-	if [ -e "$ESDE_toolPath" ]; then
-        ESDE_junksettingsFile
-        ESDE_addCustomSystemsFile
+	if [ -e "$ESDE_toolPath" ] || [ -f "${toolsPath}/$ESDE_downloadedToolName" ] || [ -f "${toolsPath}/$ESDE_oldtoolName.AppImage" ]; then
 		Yuzu_addESConfig
-        ESDE_setEmulationFolder
 	else
 		echo "ES-DE not found. Skipped adding custom system."
 	fi
@@ -380,6 +377,11 @@ Yuzu_flushEmulatorLauncher(){
 }
 
 Yuzu_addESConfig(){
+
+    ESDE_junksettingsFile
+    ESDE_addCustomSystemsFile
+    ESDE_setEmulationFolder
+
 	if [[ $(grep -rnw "$es_systemsFile" -e 'switch') == "" ]]; then
 		xmlstarlet ed -S --inplace --subnode '/systemList' --type elem --name 'system' \
 		--var newSystem '$prev' \

--- a/functions/ToolScripts/emuDeckESDE.sh
+++ b/functions/ToolScripts/emuDeckESDE.sh
@@ -111,13 +111,17 @@ ESDE_init(){
 	ESDE_addCustomSystemsFile
 	
 	mkdir -p "$ESDE_newConfigDirectory/settings"
+	mkdir -p "$ESDE_newConfigDirectory/custom_systems/"
 	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/es_settings.xml" "$(dirname "$es_settingsFile")" --backup --suffix=.bak
 	rsync -avhp --mkpath "$EMUDECKGIT/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml" "$(dirname "$es_rulesFile")" --backup --suffix=.bak
+	# This duplicates ESDE_addCustomSystemsFile but this line only applies only if you are resetting ES-DE and not the emulators themselves. 
+	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --backup --suffix=.bak
 
 	cp -r "$EMUDECKGIT/tools/launchers/es-de/." "$toolsPath/launchers/es-de/" && chmod +x "$toolsPath/launchers/es-de/es-de.sh"
 
 	ESDE_addCustomSystems
 	ESDE_setEmulationFolder
+	ESDE_setDefaultSettings
 	ESDE_setDefaultEmulators
 	ESDE_applyTheme  "$esdeThemeUrl" "$esdeThemeName"
 	ESDE_migrateDownloadedMedia
@@ -153,9 +157,11 @@ ESDE_update(){
 	#update es_settings.xml
 	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/es_settings.xml" "$(dirname "$es_settingsFile")" --ignore-existing
 	rsync -avhp --mkpath "$EMUDECKGIT/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml" "$(dirname "$es_rulesFile")" --ignore-existing
+	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --ignore-existing
 
 	ESDE_addCustomSystems
 	ESDE_setEmulationFolder
+	ESDE_setDefaultSettings
 	ESDE_setDefaultEmulators
 	ESDE_applyTheme "$esdeThemeUrl" "$esdeThemeName"
 	ESDE_migrateDownloadedMedia
@@ -192,7 +198,7 @@ ESDE_addCustomSystemsFile(){
 
 	# Separate function so it can be copied and used in the emulator scripts. 
 	mkdir -p "$ESDE_newConfigDirectory/custom_systems/"
-	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --backup --suffix=.bak
+	rsync -avhp --mkpath "$EMUDECKGIT/configs/emulationstation/custom_systems/es_systems.xml" "$(dirname "$es_systemsFile")" --ignore-existing
 
 }
 
@@ -360,8 +366,12 @@ ESDE_setEmulationFolder(){
 		fi
 	fi
 
-
 	echo "updating $es_settingsFile"
+
+}
+
+ESDE_setDefaultSettings(){
+
 	#configure roms Directory
 	esDE_romDir="<string name=\"ROMDirectory\" value=\"${romsPath}\" />" #roms
 
@@ -380,6 +390,7 @@ ESDE_setEmulationFolder(){
 		echo "setting ES-DE MediaDirectory to ${esDE_MediaDir}"
 		changeLine '<string name="MediaDirectory"' "${esDE_MediaDir}" "$es_settingsFile"
 	fi
+
 }
 
 ESDE_setDefaultEmulators(){

--- a/functions/helperFunctions.sh
+++ b/functions/helperFunctions.sh
@@ -932,6 +932,11 @@ isLatestVersionGH() {
 	fi
 }
 
+addProtonLaunch(){
+	rsync -avhp "$EMUDECKGIT/tools/proton-launch.sh" "${toolsPath}"
+	rsync -avhp "$EMUDECKGIT/tools/appID.py" "${toolsPath}"
+	chmod +x "${toolsPath}/proton-launch.sh"
+}
 
 function emulatorInit(){
 	local emuName=$1
@@ -1094,3 +1099,4 @@ function controllerLayout_BAYX(){
 	melonDS_setBAYXstyle
 	RMG_setBAYXstyle
 }
+


### PR DESCRIPTION
* Added rsyncing proton-launch.sh and appID.py to xenia and bigpemu so if users delete them accidentally, they have an easy way of getting fresh files.
* Moved resetting ES-DE's settings into its own function so if users reset any of the custom system emulators, they don't also have their settings reset.
    * This was also causing failure in very niche cases where if users didn't have a full suite of ES-DE configs, resetting the config would also fail.
* Cleaned up functions a little for easier maintenance.
* Added detection for old ES-DE installs so resetting config on custom system emulators actually grabs the latest custom systems file.
* Split BigPEmu custom system insertion into atarijaguar and atarijaguarcd
* Adjusted custom systems insertion to be less aggressive (if resetting emulators and not ES-DE, custom systems will be inserted instead of replacing the custom systems file)