### PR TITLE
Remote Play Clients: Add missing launchers

### DIFF
--- a/functions/RemotePlayClientScripts/remotePlayGreenlight.sh
+++ b/functions/RemotePlayClientScripts/remotePlayGreenlight.sh
@@ -15,6 +15,10 @@ Greenlight_install() {
 	else
 		return 0
 	fi
+
+	cp "$EMUDECKGIT/tools/remoteplayclients/Greenlight.sh" "$romsPath/remoteplay"
+	chmod +x "$romsPath/remoteplay/Greenlight.sh"
+	
 }
 
 # ApplyInitialSettings

--- a/functions/RemotePlayClientScripts/remotePlayShadow.sh
+++ b/functions/RemotePlayClientScripts/remotePlayShadow.sh
@@ -17,6 +17,9 @@ ShadowPC_install() {
 	else
         return 0
     fi
+
+	cp "$EMUDECKGIT/tools/remoteplayclients/ShadowPC.sh" "$romsPath/remoteplay"
+	chmod +x "$romsPath/remoteplay/ShadowPC.sh"
 }
 
 # ApplyInitialSettings

--- a/tools/remoteplayclients/Greenlight.sh
+++ b/tools/remoteplayclients/Greenlight.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source $HOME/.config/EmuDeck/backend/functions/all.sh
+
+"$romsPath/remoteplay/Greenlight.AppImage"

--- a/tools/remoteplayclients/ShadowPC.sh
+++ b/tools/remoteplayclients/ShadowPC.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source $HOME/.config/EmuDeck/backend/functions/all.sh
+
+"$romsPath/remoteplay/ShadowPC.AppImage"

--- a/tools/remoteplayclients/Spotify.sh
+++ b/tools/remoteplayclients/Spotify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/flatpak run --branch=stable --arch=x86_64 --file-forwarding com.spotify.Client @@u @@

--- a/tools/remoteplayclients/SteamLink.sh
+++ b/tools/remoteplayclients/SteamLink.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/flatpak run --branch=stable --arch=x86_64 --file-forwarding com.valvesoftware.SteamLink @@u @@


### PR DESCRIPTION
* Added missing launchers for Greenlight, ShadowPC, Spotify, and Steam Link 
   * If users installed these previously, these would not be added to the remoteplay folder