### PR TITLE
Cemu: Enable auto-updater

### DIFF
--- a/configs/cemu/config/cemu/settings.xml
+++ b/configs/cemu/config/cemu/settings.xml
@@ -7,7 +7,7 @@
     <language>0</language>
     <use_discord_presence>false</use_discord_presence>
     <fullscreen_menubar>false</fullscreen_menubar>
-    <check_update>false</check_update>
+    <check_update>true</check_update>
     <save_screenshot>true</save_screenshot>
     <vk_warning>false</vk_warning>
     <gp_download>true</gp_download>


### PR DESCRIPTION
This was added in the most recent update of Cemu, enable by default so users can easily update Cemu.