### PR TITLE
RetroArch: Hotfix N64 texture pack paths

### DIFF
--- a/functions/EmuScripts/emuDeckRetroArch.sh
+++ b/functions/EmuScripts/emuDeckRetroArch.sh
@@ -60,13 +60,6 @@ RetroArch_init(){
 	ln -s "$biosPath"/HdPacks/ "$emulationPath"/hdpacks/nes
 	echo "Put your Mesen HD Packs here. Remember to put the pack inside a folder here with the exact name of the rom" > "$emulationPath"/hdpacks/nes/readme.txt
 
-	#N64
-	unlink "$emulationPath"/hdpacks/Mupen64plus_next 2>/dev/null #refresh link if moved
-	mkdir "$biosPath"/Mupen64plus
-	ln -s "$biosPath"/Mupen64plus/cache/ "$emulationPath"/hdpacks/n64
-	echo "Put your Nintendo64 HD Packs here in HTS format. You can download them from https://emulationking.com/nintendo64/" > "$emulationPath"/hdpacks/n64/readme.txt
-
-
 	RetroArch_backupConfigs
 	configEmuFP "${RetroArch_emuName}" "${RetroArch_emuPath}" "true"
 	RetroArch_setEmulationFolder
@@ -1794,24 +1787,43 @@ RetroArch_Mupen64Plus_Next_setUpCoreOpt(){
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-virefresh' '"Auto"'
 
 	# hd pack settings
-	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txHiresEnable' '"True"'
-	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txHiresFullAlphaChannel' '"True"'
-	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txCacheCompression' '"True"'
-	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-EnableEnhancedHighResStorage' '"True"'
+	# Commenting these out. These seem to be causing a lot of graphical issues. 
+	#RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txHiresEnable' '"True"'
+	#RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txHiresFullAlphaChannel' '"True"'
+	#RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txCacheCompression' '"True"'
+	#RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-EnableEnhancedHighResStorage' '"True"'
+	#RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-EnableEnhancedTextureStorage' '"False"' # lazy loading
+	
+	# revert hd pack settings
+	# These seem to be causing a lot of graphical issues. 
+	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txHiresEnable' '"False"'
+	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txHiresFullAlphaChannel' '"False"'
+	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-txCacheCompression' '"False"'
+	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-EnableEnhancedHighResStorage' '"False"'
 	RetroArch_setOverride 'Mupen64Plus-Next.opt' 'Mupen64Plus-Next'  'mupen64plus-EnableEnhancedTextureStorage' '"False"' # lazy loading
+
 }
 
 #  setupHdPacks()
 RetroArch_Mupen64Plus_Next_setUpHdPacks(){
-  local texturePackPath="$HOME/.var/app/org.libretro.RetroArch/config/retroarch/system/Mupen64plus/hires_texture"
+  	local texturePackPath="$HOME/.var/app/org.libretro.RetroArch/config/retroarch/system/Mupen64plus/hires_texture"
 	local textureCachePath="$HOME/.var/app/org.libretro.RetroArch/config/retroarch/system/Mupen64plus/cache"
 
-	mkdir -p "$texturePackPath"
-	mkdir -p "$textureCachePath"
-	mkdir -p "$emulationPath/hdpacks/retroarch/Mupen64plus"
+	# Something in the install is causng infinite symlinks, commenting these lines out for now and deleting folders. Needs more thorough testing. 
+	rm -rf "$emulationPath/hdpacks/retroarch/Mupen64plus"
+	rm -rf "$biosPath/Mupen64plus/cache/"
 
-	ln -s "$emulationPath/hdpacks/retroarch/Mupen64plus/hires_texture" "$texturePackPath"
-	ln -s "$emulationPath/hdpacks/retroarch/Mupen64plus/cache" "$textureCachePath"
+	#mkdir -p "$texturePackPath"
+	#mkdir -p "$textureCachePath"
+	#mkdir -p "$emulationPath/hdpacks/retroarch/Mupen64plus"
+	#ln -s "$emulationPath/hdpacks/retroarch/Mupen64plus/hires_texture" "$texturePackPath"
+	#ln -s "$emulationPath/hdpacks/retroarch/Mupen64plus/cache" "$textureCachePath"
+	#N64
+	#unlink "$emulationPath"/hdpacks/Mupen64plus_next 2>/dev/null #refresh link if moved
+	#mkdir "$biosPath"/Mupen64plus
+	#ln -s "$biosPath"/Mupen64plus/cache/ "$emulationPath"/hdpacks/n64
+	#echo "Put your Nintendo64 HD Packs here in HTS format. You can download them from https://emulationking.com/nintendo64/" > "$emulationPath"/hdpacks/n64/readme.txt
+
 }
 
 RetroArch_Beetle_PSX_HW_setUpCoreOpt(){


### PR DESCRIPTION
* This was creating infinite symlinks, commented out and delete the folders for now. Can re-add in the future after more testing.
* Reverted texture pack path settings, this was causing an increase in graphical issues in RA's N64 core.