### PR TITLE
Exclude ChimeraOS's retroarch from ES-DE's find rules

### DIFF
--- a/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -11,7 +11,6 @@
     <emulator name="RETROARCH">
         <rule type="systempath">
             <entry>org.libretro.RetroArch</entry>
-            <entry>retroarch</entry>
         </rule>
         <rule type="staticpath">
             <entry>~/.local/share/flatpak/exports/bin/org.libretro.RetroArch</entry>


### PR DESCRIPTION
ChimeraOS includes its own copy of RetroArch, located at /usr/bin/retroarch.  When using Emudeck's EmulationStation-DE to launch retroarch, there are cases where ES-DE will launch ChimeraOS's copy of retroarch rather than the version provided by EmuDeck.  If the ChimeraOS version is launched, it doesn't properly load EmuDeck's retroarch configurations.  This is most noticeable when launching a retroarch core and seeing a startup message indicating that a controller configuration could not be found.

The fix for this is to exclude the ChimeraOS retroarch binary from the ES-DE's es_find_rules.xml.