### PR TITLE
Steam ROM Manager: Hotfix controller templates

### DIFF
--- a/configs/steam-input/emudeck_controller_generic.vdf
+++ b/configs/steam-input/emudeck_controller_generic.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_ps4.vdf
+++ b/configs/steam-input/emudeck_controller_ps4.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_ps5.vdf
+++ b/configs/steam-input/emudeck_controller_ps5.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_ps5_dualsense_edge.vdf
+++ b/configs/steam-input/emudeck_controller_ps5_dualsense_edge.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_steamcontroller.vdf
+++ b/configs/steam-input/emudeck_controller_steamcontroller.vdf
@@ -2,27 +2,22 @@
 {
 	"version"		"3"
 	"revision"		"194"
-	"title"		"EmuDeck - Frontend Controller Hotkeys"
-	"description"		"Press the Steam button + A button to view hotkeys. Intended to be used with emulator frontends (Pegasus, ES-DE). Hold Start to switch between Cemu, Citra, melonDS (Standalone), and mGBA (Standalone) Hotkeys layer. If you are using the melonDS DS and mGBA RetroArch cores, use the All Hotkeys layer."
+	"title"		"EmuDeck - Controller Hotkeys"
+	"description"		"Press the Steam button + A button to view hotkeys. Combo Hotkeys using Button Chords for Cemu, Citra, melonDS (Standalone), and mGBA (Standalone). This profile is not for the mGBA and melonDS DS RetroArch cores. Emulators not listed already have controller hotkeys mapped."
 	"creator"		"76561199036238022"
 	"progenitor"		""
 	"url"		"template://emudeck_controller_steamcontroller.vdf"
 	"export_type"		"template"
-	"controller_type"		"steamcontroller_gordon"
+	"controller_type"		"controller_steamcontroller_gordon"
 	"controller_caps"		"23117823"
 	"major_revision"		"0"
 	"minor_revision"		"0"
 	"Timestamp"		"0"
 	"actions"
 	{
-		"Preset_1000002"
+		"Preset_1000001"
 		{
-			"title"		"EmuDeck Controller Hotkeys - All"
-			"legacy_set"		"1"
-		}
-		"Preset_1000003"
-		{
-			"title"		"EmuDeck Controller Hotkeys - Cemu, Citra, melonDS, and mGBA"
+			"title"		"EmuDeck Controller Hotkeys"
 			"legacy_set"		"1"
 		}
 	}
@@ -33,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"
@@ -228,368 +223,7 @@
 	}
 	"group"
 	{
-		"id"		"111"
-		"mode"		"absolute_mouse"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Soft_Press"
-					{
-						"bindings"
-						{
-							"binding"		"mouse_button LEFT, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"110"
-		"mode"		"absolute_mouse"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Soft_Press"
-					{
-						"bindings"
-						{
-							"binding"		"mouse_button RIGHT, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"109"
-		"mode"		"joystick_move"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"deadzone_enable_type"		"1"
-		}
-	}
-	"group"
-	{
-		"id"		"108"
-		"mode"		"joystick_move"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button JOYSTICK_LEFT, Reset Emulation - Select + L3, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"deadzone_enable_type"		"1"
-		}
-	}
-	"group"
-	{
-		"id"		"107"
-		"mode"		"dpad"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"dpad_north"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_UP, Start + DPad Up - Special Hotkey 1, , "
-						}
-					}
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"dpad_south"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_DOWN, Start + DPad Down - Special Hotkey 2, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"dpad_east"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_RIGHT, Start + DPad Right - Special Hotkey 4, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"dpad_west"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_LEFT, Start + DPad Left - Special Hotkey 3, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"requires_click"		"0"
-			"haptic_intensity_override"		"0"
-		}
-	}
-	"group"
-	{
-		"id"		"105"
-		"mode"		"trigger"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"edge"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, Fast Forward - Select + R2, , "
-						}
-						"settings"
-						{
-							"haptic_intensity"		"2"
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"output_trigger"		"2"
-		}
-	}
-	"group"
-	{
-		"id"		"104"
-		"mode"		"trigger"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"edge"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, Rewind - Select + L2 (If Enabled), , "
-						}
-						"settings"
-						{
-							"haptic_intensity"		"2"
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"output_trigger"		"1"
-		}
-	}
-	"group"
-	{
-		"id"		"103"
-		"mode"		"four_buttons"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"button_a"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button A, Pause/Play - Select + A, , "
-						}
-					}
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_b"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button B, Screenshot - Select + B, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_x"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button X, Select + X - Special Hotkey 5, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_y"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button Y, Select + Y - Special Hotkey 6, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"112"
-		"mode"		"dpad"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-		}
-		"settings"
-		{
-			"requires_click"		"0"
-		}
-	}
-	"group"
-	{
-		"id"		"114"
+		"id"		"94"
 		"mode"		"four_buttons"
 		"name"		""
 		"description"		""
@@ -709,7 +343,7 @@
 	}
 	"group"
 	{
-		"id"		"115"
+		"id"		"95"
 		"mode"		"absolute_mouse"
 		"name"		""
 		"description"		""
@@ -739,7 +373,7 @@
 	}
 	"group"
 	{
-		"id"		"116"
+		"id"		"96"
 		"mode"		"absolute_mouse"
 		"name"		""
 		"description"		""
@@ -769,7 +403,7 @@
 	}
 	"group"
 	{
-		"id"		"117"
+		"id"		"97"
 		"mode"		"joystick_move"
 		"name"		""
 		"description"		""
@@ -783,7 +417,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_LEFT, Exit Full Screen - Start + L3, , "
+							"binding"		"xinput_button JOYSTICK_LEFT, Exit Full Screen - Start + L3 Reset Emulation - Select + L3, , "
 						}
 						"settings"
 						{
@@ -810,7 +444,6 @@
 						"settings"
 						{
 							"chord_button"		"15"
-							"haptic_intensity"		"3"
 						}
 					}
 				}
@@ -827,7 +460,7 @@
 	}
 	"group"
 	{
-		"id"		"118"
+		"id"		"98"
 		"mode"		"trigger"
 		"name"		""
 		"description"		""
@@ -861,7 +494,7 @@
 	}
 	"group"
 	{
-		"id"		"119"
+		"id"		"99"
 		"mode"		"trigger"
 		"name"		""
 		"description"		""
@@ -896,7 +529,7 @@
 	}
 	"group"
 	{
-		"id"		"120"
+		"id"		"100"
 		"mode"		"joystick_move"
 		"name"		""
 		"description"		""
@@ -910,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -937,7 +570,7 @@
 	}
 	"group"
 	{
-		"id"		"121"
+		"id"		"101"
 		"mode"		"dpad"
 		"name"		""
 		"description"		""
@@ -1077,7 +710,7 @@
 	}
 	"group"
 	{
-		"id"		"122"
+		"id"		"102"
 		"mode"		"dpad"
 		"name"		""
 		"description"		""
@@ -1091,7 +724,7 @@
 	}
 	"group"
 	{
-		"id"		"106"
+		"id"		"93"
 		"mode"		"switches"
 		"name"		""
 		"description"		""
@@ -1105,178 +738,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button START, Hold Start - Switch to Cemu Citra melonDS and mGBA Hotkeys, , "
-						}
-						"settings"
-						{
-							"interruptable"		"0"
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action CHANGE_PRESET 2 1 1, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"1000"
-							"haptic_intensity"		"3"
-							"delay_start"		"25"
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_menu"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button SELECT, Select + Start - Stop Emulation, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"left_bumper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button SHOULDER_LEFT, Select + L1 - Save State / Start + L1 - Previous Save State Slot, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"right_bumper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_left"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_right"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_left_upper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_right_upper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_capture"
-			{
-				"activators"
-				{
-					"release"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action system_key_1, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"113"
-		"mode"		"switches"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"button_escape"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button START, Stop Emulation - Select + Start / Hold Start - Switch to All Hotkeys, , "
+							"binding"		"xinput_button START, Stop Emulation - Select + Start, , "
 						}
 					}
 					"Long_Press"
@@ -1296,18 +758,6 @@
 						"settings"
 						{
 							"chord_button"		"15"
-							"haptic_intensity"		"3"
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action CHANGE_PRESET 1 1 1, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"1000"
 							"haptic_intensity"		"3"
 						}
 					}
@@ -1505,37 +955,19 @@
 	"preset"
 	{
 		"id"		"0"
-		"name"		"Preset_1000002"
+		"name"		"Preset_1000001"
 		"group_source_bindings"
 		{
-			"106"		"switch active"
-			"103"		"button_diamond active"
-			"110"		"left_trackpad active"
-			"111"		"right_trackpad active"
-			"108"		"joystick active"
-			"104"		"left_trigger active"
-			"105"		"right_trigger active"
-			"109"		"right_joystick active"
-			"107"		"dpad active"
-			"112"		"gyro active"
-		}
-	}
-	"preset"
-	{
-		"id"		"1"
-		"name"		"Preset_1000003"
-		"group_source_bindings"
-		{
-			"113"		"switch active"
-			"114"		"button_diamond active"
-			"115"		"left_trackpad active"
-			"116"		"right_trackpad active"
-			"117"		"joystick active"
-			"118"		"left_trigger active"
-			"119"		"right_trigger active"
-			"120"		"right_joystick active"
-			"121"		"dpad active"
-			"122"		"gyro active"
+			"93"		"switch active"
+			"94"		"button_diamond active"
+			"95"		"left_trackpad active"
+			"96"		"right_trackpad active"
+			"97"		"joystick active"
+			"98"		"left_trigger active"
+			"99"		"right_trigger active"
+			"100"		"right_joystick active"
+			"101"		"dpad active"
+			"102"		"gyro active"
 		}
 	}
 	"settings"

--- a/configs/steam-input/emudeck_controller_steamdeck.vdf
+++ b/configs/steam-input/emudeck_controller_steamdeck.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_steamdeck_radial_menus.vdf
+++ b/configs/steam-input/emudeck_controller_steamdeck_radial_menus.vdf
@@ -248,7 +248,7 @@
 	{
 		"english"
 		{
-			"title"		"EmuDeck - EmulationStation-DE"
+			"title"		"EmuDeck - Steam Deck Radial Menus"
 			"description"		"Left Touchpad - Quick Actions. Short press to perform an action."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_switch_pro.vdf
+++ b/configs/steam-input/emudeck_controller_switch_pro.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_xbox360.vdf
+++ b/configs/steam-input/emudeck_controller_xbox360.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_controller_xboxelite.vdf
+++ b/configs/steam-input/emudeck_controller_xboxelite.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"194"
-	"title"		"EmuDeck - Frontend Controller Hotkeys"
-	"description"		"Press the Xbox/Guide button + A button to view hotkeys. Intended to be used with emulator frontends (Pegasus, ES-DE). Hold Start to switch between Cemu, Citra, melonDS (Standalone), and mGBA (Standalone) Hotkeys layer. If you are using the melonDS DS and mGBA RetroArch cores, use the All Hotkeys layer."
+	"title"		"EmuDeck - Controller Hotkeys"
+	"description"		"Press the Xbox/Guide button + A button to view hotkeys. Combo Hotkeys using Button Chords for Cemu, Citra, melonDS (Standalone), and mGBA (Standalone). This profile is not for the mGBA and melonDS DS RetroArch cores. Emulators not listed already have controller hotkeys mapped."
 	"creator"		"76561199036238022"
 	"progenitor"		""
 	"url"		"template://emudeck_controller_xboxelite.vdf"
@@ -15,14 +15,9 @@
 	"Timestamp"		"0"
 	"actions"
 	{
-		"Preset_1000002"
+		"Preset_1000001"
 		{
-			"title"		"EmuDeck Controller Hotkeys - All"
-			"legacy_set"		"1"
-		}
-		"Preset_1000003"
-		{
-			"title"		"EmuDeck Controller Hotkeys - Cemu, Citra, melonDS, and mGBA"
+			"title"		"EmuDeck Controller Hotkeys"
 			"legacy_set"		"1"
 		}
 	}
@@ -33,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"
@@ -228,368 +223,7 @@
 	}
 	"group"
 	{
-		"id"		"111"
-		"mode"		"absolute_mouse"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Soft_Press"
-					{
-						"bindings"
-						{
-							"binding"		"mouse_button LEFT, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"110"
-		"mode"		"absolute_mouse"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Soft_Press"
-					{
-						"bindings"
-						{
-							"binding"		"mouse_button RIGHT, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"109"
-		"mode"		"joystick_move"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Select + R3 - Quick Menu/Toggle Full Screen, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"deadzone_enable_type"		"1"
-		}
-	}
-	"group"
-	{
-		"id"		"108"
-		"mode"		"joystick_move"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"click"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button JOYSTICK_LEFT, Reset Emulation - Select + L3, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"deadzone_enable_type"		"1"
-		}
-	}
-	"group"
-	{
-		"id"		"107"
-		"mode"		"dpad"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"dpad_north"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_UP, Start + DPad Up - Special Hotkey 1, , "
-						}
-					}
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"dpad_south"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_DOWN, Start + DPad Down - Special Hotkey 2, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"dpad_east"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_RIGHT, Start + DPad Right - Special Hotkey 4, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"dpad_west"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button DPAD_LEFT, Start + DPad Left - Special Hotkey 3, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"requires_click"		"0"
-			"haptic_intensity_override"		"0"
-		}
-	}
-	"group"
-	{
-		"id"		"105"
-		"mode"		"trigger"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"edge"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, Fast Forward - Select + R2, , "
-						}
-						"settings"
-						{
-							"haptic_intensity"		"2"
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"output_trigger"		"2"
-		}
-	}
-	"group"
-	{
-		"id"		"104"
-		"mode"		"trigger"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"edge"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, Rewind - Select + L2 (If Enabled), , "
-						}
-						"settings"
-						{
-							"haptic_intensity"		"2"
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-		"settings"
-		{
-			"output_trigger"		"1"
-		}
-	}
-	"group"
-	{
-		"id"		"103"
-		"mode"		"four_buttons"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"button_a"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button A, Pause/Play - Select + A, , "
-						}
-					}
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_b"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button B, Screenshot - Select + B, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_x"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button X, Select + X - Special Hotkey 5, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_y"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button Y, Select + Y - Special Hotkey 6, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"112"
-		"mode"		"dpad"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-		}
-		"settings"
-		{
-			"requires_click"		"0"
-		}
-	}
-	"group"
-	{
-		"id"		"114"
+		"id"		"94"
 		"mode"		"four_buttons"
 		"name"		""
 		"description"		""
@@ -709,7 +343,7 @@
 	}
 	"group"
 	{
-		"id"		"115"
+		"id"		"95"
 		"mode"		"absolute_mouse"
 		"name"		""
 		"description"		""
@@ -739,7 +373,7 @@
 	}
 	"group"
 	{
-		"id"		"116"
+		"id"		"96"
 		"mode"		"absolute_mouse"
 		"name"		""
 		"description"		""
@@ -769,7 +403,7 @@
 	}
 	"group"
 	{
-		"id"		"117"
+		"id"		"97"
 		"mode"		"joystick_move"
 		"name"		""
 		"description"		""
@@ -783,7 +417,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_LEFT, Exit Full Screen - Start + L3, , "
+							"binding"		"xinput_button JOYSTICK_LEFT, Exit Full Screen - Start + L3 Reset Emulation - Select + L3, , "
 						}
 						"settings"
 						{
@@ -810,7 +444,6 @@
 						"settings"
 						{
 							"chord_button"		"15"
-							"haptic_intensity"		"3"
 						}
 					}
 				}
@@ -827,7 +460,7 @@
 	}
 	"group"
 	{
-		"id"		"118"
+		"id"		"98"
 		"mode"		"trigger"
 		"name"		""
 		"description"		""
@@ -861,7 +494,7 @@
 	}
 	"group"
 	{
-		"id"		"119"
+		"id"		"99"
 		"mode"		"trigger"
 		"name"		""
 		"description"		""
@@ -896,7 +529,7 @@
 	}
 	"group"
 	{
-		"id"		"120"
+		"id"		"100"
 		"mode"		"joystick_move"
 		"name"		""
 		"description"		""
@@ -910,7 +543,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3 Reset Emulation - Select + L3, , "
+							"binding"		"xinput_button JOYSTICK_RIGHT, Toggle Full Screen - Select + R3, , "
 						}
 					}
 					"chord"
@@ -937,7 +570,7 @@
 	}
 	"group"
 	{
-		"id"		"121"
+		"id"		"101"
 		"mode"		"dpad"
 		"name"		""
 		"description"		""
@@ -1077,7 +710,7 @@
 	}
 	"group"
 	{
-		"id"		"122"
+		"id"		"102"
 		"mode"		"dpad"
 		"name"		""
 		"description"		""
@@ -1091,7 +724,7 @@
 	}
 	"group"
 	{
-		"id"		"106"
+		"id"		"93"
 		"mode"		"switches"
 		"name"		""
 		"description"		""
@@ -1105,178 +738,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"xinput_button START, Hold Start - Switch to Cemu Citra melonDS and mGBA Hotkeys, , "
-						}
-						"settings"
-						{
-							"interruptable"		"0"
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action CHANGE_PRESET 2 1 1, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"1000"
-							"haptic_intensity"		"3"
-							"delay_start"		"25"
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_menu"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button SELECT, Select + Start - Stop Emulation, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"left_bumper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button SHOULDER_LEFT, Select + L1 - Save State / Start + L1 - Previous Save State Slot, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"right_bumper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button SHOULDER_RIGHT, Select + R1 - Save State / Start + R1 - Next Save State Slot, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_left"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_right"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_left_upper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_back_right_upper"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action empty_binding, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-			"button_capture"
-			{
-				"activators"
-				{
-					"release"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action system_key_1, , "
-						}
-					}
-				}
-				"disabled_activators"
-				{
-				}
-			}
-		}
-	}
-	"group"
-	{
-		"id"		"113"
-		"mode"		"switches"
-		"name"		""
-		"description"		""
-		"inputs"
-		{
-			"button_escape"
-			{
-				"activators"
-				{
-					"Full_Press"
-					{
-						"bindings"
-						{
-							"binding"		"xinput_button START, Stop Emulation - Select + Start / Hold Start - Switch to All Hotkeys, , "
+							"binding"		"xinput_button START, Stop Emulation - Select + Start, , "
 						}
 					}
 					"Long_Press"
@@ -1296,18 +758,6 @@
 						"settings"
 						{
 							"chord_button"		"15"
-							"haptic_intensity"		"3"
-						}
-					}
-					"Long_Press"
-					{
-						"bindings"
-						{
-							"binding"		"controller_action CHANGE_PRESET 1 1 1, , "
-						}
-						"settings"
-						{
-							"long_press_time"		"1000"
 							"haptic_intensity"		"3"
 						}
 					}
@@ -1505,37 +955,19 @@
 	"preset"
 	{
 		"id"		"0"
-		"name"		"Preset_1000002"
+		"name"		"Preset_1000001"
 		"group_source_bindings"
 		{
-			"106"		"switch active"
-			"103"		"button_diamond active"
-			"110"		"left_trackpad active"
-			"111"		"right_trackpad active"
-			"108"		"joystick active"
-			"104"		"left_trigger active"
-			"105"		"right_trigger active"
-			"109"		"right_joystick active"
-			"107"		"dpad active"
-			"112"		"gyro active"
-		}
-	}
-	"preset"
-	{
-		"id"		"1"
-		"name"		"Preset_1000003"
-		"group_source_bindings"
-		{
-			"113"		"switch active"
-			"114"		"button_diamond active"
-			"115"		"left_trackpad active"
-			"116"		"right_trackpad active"
-			"117"		"joystick active"
-			"118"		"left_trigger active"
-			"119"		"right_trigger active"
-			"120"		"right_joystick active"
-			"121"		"dpad active"
-			"122"		"gyro active"
+			"93"		"switch active"
+			"94"		"button_diamond active"
+			"95"		"left_trackpad active"
+			"96"		"right_trackpad active"
+			"97"		"joystick active"
+			"98"		"left_trigger active"
+			"99"		"right_trigger active"
+			"100"		"right_joystick active"
+			"101"		"dpad active"
+			"102"		"gyro active"
 		}
 	}
 	"settings"

--- a/configs/steam-input/emudeck_controller_xboxone.vdf
+++ b/configs/steam-input/emudeck_controller_xboxone.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_generic.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_generic.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_ps4.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps4.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_ps5.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps5.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_ps5_dualsense_edge.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_ps5_dualsense_edge.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_steamcontroller.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_steamcontroller.vdf
@@ -8,7 +8,7 @@
 	"progenitor"		""
 	"url"		"template://emudeck_frontend_controller_steamcontroller.vdf"
 	"export_type"		"template"
-	"controller_type"		"steamcontroller_gordon"
+	"controller_type"		"controller_steamcontroller_gordon"
 	"controller_caps"		"23117823"
 	"major_revision"		"0"
 	"minor_revision"		"0"
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_steamdeck.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_steamdeck.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_switch_pro.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_switch_pro.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_xbox360.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xbox360.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_xboxelite.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xboxelite.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_frontend_controller_xboxone.vdf
+++ b/configs/steam-input/emudeck_frontend_controller_xboxone.vdf
@@ -33,7 +33,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Frontend Controller Hotkeys"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-input/emudeck_steam_deck_light_gun_controls.vdf
+++ b/configs/steam-input/emudeck_steam_deck_light_gun_controls.vdf
@@ -28,7 +28,7 @@
 	{
 		"english"
 		{
-			"title"		"Gamepad With Joystick Trackpad"
+			"title"		"EmuDeck - Steam Deck Light Gun Controls"
 			"description"		"This template is for most games that already have built-in gamepad support and have a first or third person controlled camera.  FPS or Third Person Adventure games, etc."
 		}
 		"czech"

--- a/configs/steam-rom-manager/userData/controllerTemplates.json
+++ b/configs/steam-rom-manager/userData/controllerTemplates.json
@@ -1,5 +1,5 @@
 {
-    "/home/deck/.steam/steam": {
+    "/home/deck/.local/share/Steam": {
         "ps4": [
             {
                 "title": "Gamepad",
@@ -22,11 +22,6 @@
                 "profileType": "template"
             },
             {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_ps4.vdf",
-                "profileType": "template"
-            },
-            {
                 "title": "Gamepad with Mouse and Gyro",
                 "mappingId": "controller_ps4_gamepad_mouse_gyro.vdf",
                 "profileType": "template"
@@ -37,12 +32,12 @@
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - DualShock 4",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_ps4.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - DualShock 4 Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_ps4.vdf",
                 "profileType": "template"
             }
@@ -69,11 +64,6 @@
                 "profileType": "template"
             },
             {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_ps5.vdf",
-                "profileType": "template"
-            },
-            {
                 "title": "Gamepad with Mouse and Gyro",
                 "mappingId": "controller_ps5_gamepad_mouse_gyro.vdf",
                 "profileType": "template"
@@ -84,100 +74,61 @@
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - DualSense",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_ps5.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - DualSense Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_ps5.vdf",
                 "profileType": "template"
             }
+            
         ],
         "ps5_edge": [
             {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - DualSense Edge",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - DualSense Edge Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
                 "profileType": "template"
             }
         ],
         "xbox360": [
             {
-                "title": "Gamepad",
-                "mappingId": "controller_xbox360_gamepad_joystick.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_xbox360.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "Keyboard (WASD) and Mouse",
-                "mappingId": "controller_xbox360_wasd.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - Xbox 360",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_xbox360.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Xbox 360 Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_xbox360.vdf",
                 "profileType": "template"
             }
         ],
         "xboxone": [
             {
-                "title": "Gamepad",
-                "mappingId": "controller_xboxone_gamepad_joystick.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_xboxone.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "Keyboard (WASD) and Mouse",
-                "mappingId": "controller_xboxone_wasd.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - Xbox One",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_xboxone.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Xbox One Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_xboxone.vdf",
                 "profileType": "template"
             }
         ],
         "xboxelite": [
             {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - Xbox Elite",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_xboxelite.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Xbox Elite Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
                 "profileType": "template"
             }
@@ -208,37 +159,17 @@
                 "profileType": "template"
             },
             {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "Keyboard (WASD) and Mouse",
-                "mappingId": "controller_switch_pro_wasd.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - Switch Pro Controller",
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_switch_pro.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Switch Pro Controller Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
                 "profileType": "template"
             }
         ],
         "neptune": [
-            {
-                "title": "EmuDeck - Cloud",
-                "mappingId": "emudeck_cloud_controller_config.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - EmulationStation-DE",
-                "mappingId": "emudeck_controller_steamdeck_radial_menus.vdf",
-                "profileType": "template"
-            },
             {
                 "title": "Gamepad",
                 "mappingId": "controller_neptune_gamepad_joystick.vdf",
@@ -247,11 +178,6 @@
             {
                 "title": "Gamepad with Gyro",
                 "mappingId": "controller_neptune_gamepad_mouse_gyro.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "Gamepad With Joystick Trackpad",
-                "mappingId": "emudeck_steam_deck_light_gun_controls.vdf",
                 "profileType": "template"
             },
             {
@@ -280,18 +206,18 @@
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Steam Deck",
+                "title": "EmuDeck - Cloud",
+                "mappingId": "emudeck_cloud_controller_config.vdf",
+                "profileType": "template"
+            },
+            {
+                "title": "EmuDeck - Controller Hotkeys",
                 "mappingId": "emudeck_controller_steamdeck.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Steam Deck Frontend",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
                 "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - Cloud",
-                "mappingId": "emudeck_cloud_controller_config.vdf",
                 "profileType": "template"
             },
             {
@@ -300,13 +226,8 @@
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Steam Deck",
-                "mappingId": "emudeck_controller_steamdeck_nintendo.vdf",
-                "profileType": "template"
-            },
-            {
-                "title": "EmuDeck - Steam Deck Proton",
-                "mappingId": "emudeck_controller_steamdeck_proton.vdf",
+                "title": "EmuDeck - Steam Deck Light Gun Controls",
+                "mappingId": "emudeck_steam_deck_light_gun_controls.vdf",
                 "profileType": "template"
             }
         ],
@@ -317,13 +238,13 @@
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Steam Controller Frontend",
-                "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
                 "profileType": "template"
             },
             {
-                "title": "EmuDeck - Steam Controller",
-                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
                 "profileType": "template"
             }
         ]

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -1,9098 +1,9607 @@
 [
-  {
-      "parserType": "Glob",
-      "configTitle": "ES-DE",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Emulation}",
-      "romDirectory": "/run/media/mmcblk0p1/Emulation/tools/launchers/es-de/",
-      "executableArgs": "",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/es-de/es-de.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.sh)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": false,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4 Frontend",
-              "mappingId": "emudeck_frontend_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense Frontend",
-              "mappingId": "emudeck_frontend_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge Frontend",
-              "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360 Frontend",
-              "mappingId": "emudeck_frontend_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One Frontend",
-              "mappingId": "emudeck_frontend_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite Frontend",
-              "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller Frontend",
-              "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck Frontend",
-              "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller Frontend",
-              "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static",
-                  "animated"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164824496516097458",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Pegasus - Pegasus Frontend",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Emulation}",
-      "romDirectory": "/run/media/mmcblk0p1/Emulation/tools/launchers/pegasus/",
-      "executableArgs": "",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "Pegasus Frontend",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/pegasus/pegasus-frontend.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.sh)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4 Frontend",
-              "mappingId": "emudeck_frontend_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense Frontend",
-              "mappingId": "emudeck_frontend_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge Frontend",
-              "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360 Frontend",
-              "mappingId": "emudeck_frontend_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One Frontend",
-              "mappingId": "emudeck_frontend_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite Frontend",
-              "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller Frontend",
-              "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck Frontend",
-              "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller Frontend",
-              "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static",
-                  "animated"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164824496516097459",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Emulators - Emulators",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Emulation}",
-      "romDirectory": "/run/media/mmcblk0p1/Emulation/tools/launchers",
-      "executableArgs": "",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.sh)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4 Frontend",
-              "mappingId": "emudeck_frontend_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense Frontend",
-              "mappingId": "emudeck_frontend_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge Frontend",
-              "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360 Frontend",
-              "mappingId": "emudeck_frontend_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One Frontend",
-              "mappingId": "emudeck_frontend_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite Frontend",
-              "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller Frontend",
-              "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck Frontend",
-              "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller Frontend",
-              "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164824333516097458",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Cloud Services - Cloud Services",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Cloud Services}",
-      "romDirectory": "${romsdirglobal}/cloud",
-      "executableArgs": "",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "${romsdirglobal}/cloud",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.sh)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": false,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": {
-              "title": "EmuDeck - Cloud",
-              "mappingId": "emudeck_cloud_controller_config.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "Gamepad with Mouse and Gyro",
-              "mappingId": "gamepad_mouse_gyro.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785598905497513",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Remote Play Clients - Remote Play Clients",
-      "steamCategory": "${Remote Play Clients}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/remoteplay",
-      "executableArgs": "",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "${romsdirglobal}/remoteplay",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.sh|.AppImage)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": false,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164785598905497514",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": {
-              "title": "EmuDeck - Cloud",
-              "mappingId": "emudeck_cloud_controller_config.vdf",
-              "profileType": "template"
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Amiga - RetroArch PUAE",
-      "steamCategory": "${Amiga}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/amiga",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598905398120",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Amiga 600 - RetroArch PUAE",
-      "steamCategory": "${Amiga 600}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/amiga600",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598905398121",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Amiga 1200 - RetroArch PUAE",
-      "steamCategory": "${Amiga 1200}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/amiga1200",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598905398122",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Amiga CD - RetroArch PUAE",
-      "steamCategory": "${Amiga CD}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/amigacd32",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598905398123",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Amstrad CPC - RetroArch Caprice32",
-      "steamCategory": "${Amstrad CPC}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/amstradcpc",
-      "executableArgs": "-L /cap32_libretro.so \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.7z|.7Z|.cdt|.CDT|.dsk|.DSK|.sna|.SNA|.tap|.TAP|.voc|.VOC|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "166486574949993186",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - Atomiswave - Flycast (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Arcade - Atomiswave - Flycast (Standalone)}",
-      "romDirectory": "${romsdirglobal}/atomiswave",
-      "executableArgs": "\"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785622173694321",
-      "version": 17,
-      "disabled": false,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - MAME (Standalone)",
-      "steamCategory": "${Arcade}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/arcade",
-      "executableArgs": " \"${fileName}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "165964954316677671",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - NAOMI - RetroArch Flycast",
-      "steamCategory": "${Arcade - NAOMI}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/naomi",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}flycast_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "165768545254166037",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - NAOMI - Flycast (Standalone)",
-      "steamCategory": "${Arcade - NAOMI - Flycast (Standalone)}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/naomi",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "\"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserId": "164285091855061150",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - NAOMI 2 - Flycast (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Arcade - NAOMI 2 - Flycast (Standalone)}",
-      "romDirectory": "${romsdirglobal}/naomi2",
-      "executableArgs": "\"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785622173694322",
-      "version": 17,
-      "disabled": false,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - RetroArch FBNeo",
-      "steamCategory": "${Arcade - FBNeo}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fbneo_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/fbneo",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(7z|7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "164824416516097457",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - RetroArch MAME 2003 Plus",
-      "steamCategory": "${Arcade - MAME 2003 Plus}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/mame",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mame2003_plus_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785580134372556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - RetroArch MAME 2010",
-      "steamCategory": "${Arcade - MAME 2010}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/mame",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mame2010_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164585567134532556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Arcade - RetroArch MAME Current",
-      "steamCategory": "${Arcade - MAME Current}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/arcade",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mame_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785567134372556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Atari 2600 - RetroArch Stella",
-      "steamCategory": "${Atari 2600}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/atari2600",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}stella_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.a26|.A26|.bin|.BIN|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785583010740299",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Atari Jaguar - BigPEmu Proton",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Atari Jaguar}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "\"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "@(atarijaguar|atarijaguarcd)/**/${title}@(j64|.J64|.cof|.COF|.rom|.ROM|.jag|.JAG|.abs|.ABS|.zip|.ZIP|.cue|.CUE|.cdi|.CDI)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164824416518097459",
-      "version": 17,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Atari Jaguar - RetroArch Virtual Jaguar",
-      "steamCategory": "${Atari Jaguar}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/atarijaguar",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}virtualjaguar_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.j64|.J64|.jag|.JAG|.rom|.ROM|.abs|.ABS|.cof|.COF|.bin|.BIN|.prg|.PRG|.7z|.7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "16476758151010299",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Atari Lynx - RetroArch Beetle Handy",
-      "steamCategory": "${Atari Lynx}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/atarilynx",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_lynx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.lnx|.LNX|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785590686474494",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Bandai WonderSwan - RetroArch Beetle Cygne",
-      "steamCategory": "${Bandai WonderSwan}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/wonderswan",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_wswan_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785595449272607",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Bandai WonderSwan Color - RetroArch Beetle Cygne",
-      "steamCategory": "${Bandai WonderSwan Color}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/wonderswancolor",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_wswan_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785595449272606",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Commodore 16 - RetroArch VICE",
-      "steamCategory": "${Commodore 16}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/c16",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_xplus4_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.d64|.D64|.d71|.D71|.d80|.D80|.d81|.D81|.d82|.D82|.g64|.G64|.g41|.G41|.x64|.X64|.t64|.T64|.tap|.TAP|.prg|.PRG|.p00|.P00|.crt|.CRT|.bin|.BIN|.d6z|.D6Z|.d7z|.D7Z|.d8z|.D8Z|.g6z|.G6Z|.g4z|.G4Z|.x6z|.X6Z|.cmd|.CMD|.m3u|.M3U|.vsf|.VSF|.nib|.NIB|.nbz|.NBZ|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164712598905497531",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Commodore 64 - RetroArch VICE",
-      "steamCategory": "${Commodore 64}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/c64",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_x64_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.d64|.D64|.d71|.D71|.d80|.D80|.d81|.D81|.d82|.D82|.g64|.G64|.g41|.G41|.x64|.X64|.t64|.T64|.tap|.TAP|.prg|.PRG|.p00|.P00|.crt|.CRT|.bin|.BIN|.d6z|.D6Z|.d7z|.D7Z|.d8z|.D8Z|.g6z|.G6Z|.g4z|.G4Z|.x6z|.X6Z|.cmd|.CMD|.m3u|.M3U|.vsf|.VSF|.nib|.NIB|.nbz|.NBZ|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164785598905497512",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Commodore VIC-20 - RetroArch VICE",
-      "steamCategory": "${Commodore VIC-20}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/vic20",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_xvic_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.d64|.d6z|.d71|.d7z|.d80|.d81|.d82|.d8z|.g64|.g6z|.g41|.g4z|.x64|.x6z|.nib|.nbz|.d2m|.d4m|.t64|.tap|.tcrt|.prg|.p00|.crt|.bin|.cmd|.m3u|.vfl|.vsf|.zip|.7z|.gz|.20|.40|.60|.a0|.b0|.rom|.D64|.D6Z|.D71|.D7Z|.D80|.D81|.D82|.D8Z|.G64|.G6Z|.G41|.G4Z|.X64|.X6Z|.NIB|.NBZ|.D2M|.D4M|.T64|.TAP|.TCRT|.PRG|.P00|.CRT|.BIN|.CMD|.M3U|.VFL|.VSF|.ZIP|.7Z|.GZ|.20|.40|.60|.A0|.B0|.ROM|)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785127820983556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-    "parserType": "Glob",
-    "configTitle": "Desktop Applications",
-    "steamDirectory": "${steamdirglobal}",
-    "steamCategory": "${Desktop Applications}",
-    "romDirectory": "${romsdirglobal}",
-    "executableArgs": "",
-    "executableModifier": "\"${exePath}\"",
-    "startInDirectory": "",
-    "titleModifier": "${fuzzyTitle}",
-    "fetchControllerTemplatesButton": null,
-    "removeControllersButton": null,
-    "steamInputEnabled": "1",
-    "imageProviders": [
-        "sgdb"
-    ],
-    "onlineImageQueries": "${${fuzzyTitle}}",
-    "imagePool": "${fuzzyTitle}",
-    "drmProtect": false,
-    "userAccounts": {
-        "specifiedAccounts": ""
-    },
-    "executable": {
-        "path": "",
-        "shortcutPassthrough": true,
-        "appendArgsToExecutable": true
-    },
-    "parserInputs": {
-        "glob": "{desktop/**/!(cloud|remoteplay),desktop}/${title}@(sh|.SH|.desktop|.DESKTOP)"
-    },
-    "titleFromVariable": {
-        "limitToGroups": "",
-        "caseInsensitiveVariables": false,
-        "skipFileIfVariableWasNotFound": false,
-        "tryToMatchTitle": false
-    },
-    "fuzzyMatch": {
-        "replaceDiacritics": true,
-        "removeCharacters": true,
-        "removeBrackets": true
-    },
-    "controllers": {
-        "ps4": null,
-        "ps5": null,
-        "ps5_edge": null,
-        "xbox360": null,
-        "xboxone": null,
-        "xboxelite": null,
-        "switch_joycon_left": null,
-        "switch_joycon_right": null,
-        "switch_pro": null,
-        "neptune": null,
-        "steamcontroller_gordon": null
-    },
-    "imageProviderAPIs": {
-        "sgdb": {
-            "nsfw": false,
-            "humor": false,
-            "styles": [],
-            "stylesHero": [],
-            "stylesLogo": [],
-            "stylesIcon": [],
-            "imageMotionTypes": [
-                "static"
-            ],
-            "sizes": [],
-            "sizesHero": [],
-            "sizesIcon": []
+    {
+        "parserType": "Glob",
+        "configTitle": "ES-DE",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "/run/media/mmcblk0p1/Emulation/tools/launchers/es-de/",
+        "steamCategories": [
+            "Emulation"
+        ],
+        "executableArgs": "",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
         },
-        "steamCDN": {}
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/es-de/es-de.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.sh)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": false,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static",
+                    "animated"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164824496516097458",
+        "version": 22
     },
-    "defaultImage": {
-        "tall": "",
-        "long": "",
-        "hero": "",
-        "logo": "",
-        "icon": ""
+    {
+        "parserType": "Glob",
+        "configTitle": "Pegasus - Pegasus Frontend",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "/run/media/mmcblk0p1/Emulation/tools/launchers/pegasus/",
+        "steamCategories": [
+            "Emulation"
+        ],
+        "executableArgs": "",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "Pegasus Frontend",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/pegasus/pegasus-frontend.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.sh)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static",
+                    "animated"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164824496516097459",
+        "version": 22
     },
-    "localImages": {
-        "tall": "",
-        "long": "",
-        "hero": "",
-        "logo": "",
-        "icon": ""
+    {
+        "parserType": "Glob",
+        "configTitle": "Emulators - Emulators",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "/run/media/mmcblk0p1/Emulation/tools/launchers",
+        "steamCategories": [
+            "Emulation"
+        ],
+        "executableArgs": "",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.sh)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164824333516097458",
+        "version": 22
     },
-    "parserId": "171773288577350796",
-    "version": 18
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "DooM - RetroArch PrBoom",
-      "steamCategory": "${DooM}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/doom",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}prboom_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.wad|.WAD|.iwad|.IWAD|.pwad|.PWAD|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785092749272606",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "DOS - RetroArch DOSBox Pure",
-      "steamCategory": "${DOS}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}dosbox_pure_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/dos",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "165155371770791847",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Intellivision - RetroArch FreeIntv",
-      "steamCategory": "${Mattel Electronics Intellivision}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/intellivision",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}freeintv_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.int|.INT|.bin|.BIN|.rom|.ROM|.7z|.7Z|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164789998905398117",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Microsoft Xbox 360 - Xenia",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Microsoft Xbox 360}",
-      "romDirectory": "${romsdirglobal}/xbox360",
-      "executableArgs": "\"Z:${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "{roms/**/!(xbla),roms}/**/${title}@(.iso|.ISO|.xex|.XEX|.zar|.ZAR)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "animated"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "135113607715086732",
-      "version": 17,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Microsoft Xbox 360 - Xbox Live Arcade - Xenia",
-      "steamCategory": "${Microsoft Xbox 360 - Xbox Live Arcade}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/xbox360/roms/",
-      "executableArgs": "\"Z:${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "xbla/**/${title}"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "167851246183635366",
-      "version": 17,
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Microsoft Xbox - Xemu",
-      "steamCategory": "${Microsoft Xbox}",
-      "executableArgs": " -full-screen -dvd_path \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/xbox",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/xemu-emu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.iso|.ISO)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "165103607715056732",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "NEC PC-98 - RetroArch NP2kai",
-      "steamCategory": "${NEC PC-98}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/pc98",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}np2kai_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.d98|.zip|.98d|.fdi|.fdd|.2hd|.tfd|.d88|.88d|.hdm|.xdf|.dup|.cmd|.hdi|.thd|.nhd|.hdd|.hdn|.D98|.ZIP|.98D|.FDI|.FDD|.2HD|.TFD|.D88|.88D|.HDM|.XDF|.DUP|.CMD|.HDI|.THD|.NHD|.HDD|.HDN)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "1647850989120983556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "NEC PC Engine/TurboGrafx 16 CD - RetroArch Beetle PCE",
-      "steamCategory": "${NEC PC Engine/TurboGrafx 16 CD}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pce_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "@(pcenginecd|tg-cd)/**/${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "165856080826916450",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "NEC PC Engine/TurboGrafx 16 - RetroArch Beetle PCE",
-      "steamCategory": "${NEC PC Engine/TurboGrafx 16}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pce_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "@(pcengine|tg16)/**/${title}@(.7z|.7Z|.bin|.BIN|.pce|.PCE|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "165855998563219386",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "PCFX - RetroArch Beetle PC-FX",
-      "steamCategory": "${NEC PC-FX}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/pcfx",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pcfx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.ccd|.CCD|.chd|.CHD|.cue|CUE|.m3u|.M3U|.toc|.TOC|.7z|.7Z|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164789998905398116",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo 3DS - RetroArch Citra",
-      "steamCategory": "${Nintendo 3DS - RetroArch Citra}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/n3ds",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}citra_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.3ds|.3DS|.3dsx|.3DSX|.app|.APP|.axf|.AXF|.cii|.CII|.cxi|.CXI|.elf|.ELF|.cci|.CCI)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164680998105308116",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo 3DS - Citra",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo 3DS}",
-      "romDirectory": "${romsdirglobal}/n3ds",
-      "executableArgs": " \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/citra.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.3ds|.3DS|.3dsx|.3DSX|.app|.APP|.axf|.AXF|.cii|.CII|.cxi|.CXI|.elf|.ELF|.cci|.CCI)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck_nintendo.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "16478559884003904",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo 64 - RetroArch Mupen64Plus Next",
-      "steamCategory": "${Nintendo 64}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/n64",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mupen64plus_next_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.bin|.BIN|.n64|.N64|.ndd|.NDD|.u1|.U1|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598905398114",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo 64 - Rosalie's Mupen GUI",
-      "steamCategory": "${Nintendo 64 - Rosalie's Mupen GUI}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "--fullscreen --nogui --quit-after-emulation \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rosaliesmupengui.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "@(n64|n64dd)/**/${title}@(.7z|.7Z|.bin|.BIN|.n64|.N64|.ndd|.NDD|.u1|.U1|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "167184642099963041",
-      "version": 17,
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo DS - RetroArch melonDS DS",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo DS}",
-      "romDirectory": "${romsdirglobal}/nds",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}melondsds_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.dsi|.DSI|.ids|.IDS|.nds|.NDS|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164843694520657522",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo DS - melonDS (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo DS - melonDS (Standalone)}",
-      "romDirectory": "${romsdirglobal}/nds",
-      "executableArgs": "\"${filePath}\" -f",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/melonds.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.nds|.NDS|.app|.APP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164823604520657524",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo DS - RetroArch melonDS (Legacy)",
-      "steamCategory": "${Nintendo DS - RetroArch melonDS (Legacy)}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}melonds_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/nds",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": true,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.nds|.NDS|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "164823604520657522",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy Advance - RetroArch mGBA",
-      "steamCategory": "${Nintendo Game Boy Advance}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mgba_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{gba/**/!(homebrew),gba}/${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598920514822",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy Advance - mGBA (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Game Boy Advance - mGBA (Standalone)}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "-f \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "{gba/**/!(homebrew),gba}/${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785621855061652",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy Color - RetroArch Gambatte",
-      "steamCategory": "${Nintendo Game Boy Color}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598936495323",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy Color - mGBA (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Game Boy Color - mGBA (Standalone)}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "-f \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck_nintendo.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785621855061661",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy Color - RetroArch SameBoy",
-      "steamCategory": "${Nintendo Game Boy Color - SameBoy}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785590985613234",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy - RetroArch Gambatte",
-      "steamCategory": "${Nintendo Game Boy}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{gb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785598952083233",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy - mGBA (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Game Boy - mGBA (Standalone)}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "-f \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "{gb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164385421865061350",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Game Boy - RetroArch SameBoy",
-      "steamCategory": "${Nintendo Game Boy - SameBoy}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "parserInputs": {
-          "glob": "{gb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785590985613233",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo GameCube - Dolphin",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo GameCube}",
-      "romDirectory": "${romsdirglobal}/gc",
-      "executableArgs": "vblank_mode=0 %command% -b -e \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.json|.JSON|.nkit.iso|.NKIT.ISO|.nkit.gcz|.NKIT.GCZ|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.m3u|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164770728884890304",
-      "version": 17,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Entertainment System - RetroArch Mesen",
-      "steamCategory": "${Nintendo Entertainment System}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{nes/**/!(homebrew),nes,famicom/**}/${title}@(.7z|.7Z|.nes|.NES|.fds|.FDS|.unf|.UNF|.unif|.UNIF|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785621824841888",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Metroid Prime Trilogy - PrimeHack",
-      "steamCategory": "${Nintendo Wii}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/primehacks",
-      "executableArgs": "vblank_mode=0 %command% run io.github.shiiion.primehack -b -e \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/primehack.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.json|.JSON|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.WBFS)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164770728884890305",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Super Game Boy - RetroArch Mesen S",
-      "steamCategory": "${Nintendo Super Game Boy}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen-s_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{sgb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.sgb|.SGB|.dmg|.DMG|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "16472550495204231",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo SNES (Super Nintendo) - RetroArch Snes9x",
-      "steamCategory": "${Nintendo SNES (Super Nintendo)}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}snes9x_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{snes/**/!(homebrew),snes,snesna/**}/${title}@(.7z|.7Z|.bs|.BS|.fig|.FIG|.sfc|.SFC|.smc|.SMC|.swc|.SWC|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785621840217949",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo SNES (Super Nintendo) HD - RetroArch bsnes-hd",
-      "steamCategory": "${Nintendo SNES (Super Nintendo) HD - bsnes-hd}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/sneshd",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}bsnes_hd_beta_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.bs|.BS|.fig|.FIG|.sfc|.SFC|.smc|.SMC|.swc|.SWC|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "166785621840217949",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Switch - Ryujinx",
-      "steamCategory": "${Nintendo Switch - Ryujinx}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/switch",
-      "executableArgs": "--fullscreen \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle} (Ryujinx)",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "disabled": false,
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/ryujinx.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.kip|.KIP|.nca|.NCA|.nro|.NRO|.nso|.NSO|.nsp|.NSP|.nsz|.NSZ|.xci|.XCI)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164788906872922785",
-      "version": 17,
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Switch - Yuzu",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Switch - Yuzu}",
-      "romDirectory": "${romsdirglobal}/switch",
-      "executableArgs": "vblank_mode=0 %command% -f -g \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "disabled": true,
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/yuzu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.kip|.KIP|.nca|.NCA|.nro|.NRO|.nso|.NSO|.nsp|.NSP|.xci|.XCI)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785621855061650",
-      "version": 17,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Virtual Boy - RetroArch Beetle VB",
-      "steamCategory": "${Nintendo Virtual Boy}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/virtualboy",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_vb_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.vb|.VB|.vboy|.VBOY|.bin|.BIN|.7z|.7Z|.zip|.ZIP)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164789998905398115",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Wii - Dolphin",
-      "steamCategory": "${Nintendo Wii}",
-      "executableArgs": "vblank_mode=0 %command% -b -e \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/wii",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.m3u|.M3U|.json|.JSON)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "switch_pro": null,
-          "neptune": {
-              "title": "Gamepad with Mouse Trackpad",
-              "mappingId": "controller_neptune_gamepad+mouse.vdf",
-              "profileType": "template"
-          },
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null
-      },
-      "parserId": "164770823452964732",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Wii U - Cemu Native (.rpx)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Wii U - Cemu Native}",
-      "romDirectory": "${romsdirglobal}/wiiu/roms/",
-      "executableArgs": "vblank_mode=0 %command% -f -g \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "${title}/**/*.rpx"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",
-          "hero": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/hero.png",
-          "logo": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/logo.png",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "166758881839575782",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Wii U - Cemu Native (.wud, .wux, .wua)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Wii U - Cemu Native}",
-      "romDirectory": "${romsdirglobal}/wiiu/roms/",
-      "executableArgs": "vblank_mode=0 %command% -f -g \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.elf|.ELF|.tmd|.TMD|.wua|.WUA|.wud|.WUD|.wuhb|.WUHB|.wux|.WUX)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",
-          "hero": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/hero.png",
-          "logo": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/logo.png",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "166758882107057128",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Wii U - Cemu Proton (.rpx)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Wii U - Cemu Proton}",
-      "romDirectory": "${romsdirglobal}/wiiu/roms/",
-      "executableArgs": "vblank_mode=0 %command% -w -f -g \"Z:${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle} (Proton)",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "${title}/**/*.rpx"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164824416516097458",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Nintendo Wii U - Cemu Proton (.wud, .wux, .wua)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Nintendo Wii U - Cemu Proton}",
-      "romDirectory": "${romsdirglobal}/wiiu/roms/",
-      "executableArgs": "vblank_mode=0 %command% -w -f -g \"Z:${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle} (Proton)",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.elf|.ELF|.tmd|.TMD|.wua|.WUA|.wud|.WUD|.wuhb|.WUHB|.wux|.WUX)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": {
-              "title": "EmuDeck - DualShock 4",
-              "mappingId": "emudeck_controller_ps4.vdf",
-              "profileType": "template"
-          },
-          "ps5": {
-              "title": "EmuDeck - DualSense",
-              "mappingId": "emudeck_controller_ps5.vdf",
-              "profileType": "template"
-          },
-          "ps5_edge": {
-              "title": "EmuDeck - DualSense Edge",
-              "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
-              "profileType": "template"
-          },
-          "xbox360": {
-              "title": "EmuDeck - Xbox 360",
-              "mappingId": "emudeck_controller_xbox360.vdf",
-              "profileType": "template"
-          },
-          "xboxone": {
-              "title": "EmuDeck - Xbox One",
-              "mappingId": "emudeck_controller_xboxone.vdf",
-              "profileType": "template"
-          },
-          "xboxelite": {
-              "title": "EmuDeck - Xbox Elite",
-              "mappingId": "emudeck_controller_xboxelite.vdf",
-              "profileType": "template"
-          },
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": {
-              "title": "EmuDeck - Switch Pro Controller",
-              "mappingId": "emudeck_controller_switch_pro.vdf",
-              "profileType": "template"
-          },
-          "neptune": {
-              "title": "EmuDeck - Steam Deck",
-              "mappingId": "emudeck_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": {
-              "title": "EmuDeck - Steam Controller",
-              "mappingId": "emudeck_controller_steamcontroller.vdf",
-              "profileType": "template"
-          }
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164824416518097458",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Panasonic 3DO - RetroArch Opera",
-      "steamCategory": "${Panasonic 3DO}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/3do",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}opera_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.iso|.ISO|.bin|.BIN|.chd|.CHD|.cue|.cue)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${3DO}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785580114332556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Philips CD-i - RetroArch SAME CDi",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Philips CD-i}",
-      "romDirectory": "${romsdirglobal}/cdimono1",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}same_cdi_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "fetchControllerTemplatesButton": null,
-      "removeControllersButton": null,
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.iso|.ISO|.chd|.CHD)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "164785621902122397",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Philips CD-i - MAME (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Philips CD-i - MAME}",
-      "romDirectory": "${romsdirglobal}/cdimono1",
-      "executableArgs": "cdimono1 -cdrom \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.chd|.CHD)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": {
-              "title": "Gamepad with Mouse Trackpad",
-              "mappingId": "controller_neptune_gamepad+mouse.vdf",
-              "profileType": "template"
-          },
-          "steamcontroller_gordon": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "168541242505111076",
-      "version": 17,
-      "disabled": true
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Pico 8 - RetroArch Retro8",
-      "steamCategory": "${Pico 8}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/pico8",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserId": "164785621902122396",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "RPG Maker - RetroArch EasyRPG",
-      "steamCategory": "${RPG Maker}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/easyrpg",
-      "executableArgs": "-L /easyrpg_libretro.so \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${title}}",
-      "imagePool": "${title}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "${title}/*@(.ldb|.easyrpg)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "167174183584229566",
-      "version": 17,
-      "disabled": false,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "ScummVM - ScummVM",
-      "steamCategory": "${ScummVM}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/scummvm",
-      "executableArgs": "--path=\"${filePath}\" --auto-detect",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/scummvm.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "controllers": {
-          "switch_pro": null,
-          "neptune": {
-              "title": "Gamepad with Mouse Trackpad",
-              "mappingId": "controller_neptune_gamepad+mouse.vdf",
-              "profileType": "template"
-          },
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null
-      },
-      "parserInputs": {
-          "glob": "${title}.scummvm"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "166399570436769358",
-      "version": 17,
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega 32X - RetroArch PicoDrive",
-      "steamCategory": "${Sega 32X}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/sega32x",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}picodrive_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785621902111196",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega CD/Mega CD - RetroArch Genesis Plus GX",
-      "steamCategory": "${Sega CD/Mega CD}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "@(segacd|megacd)/**/${title}@(.m3u|.M3U|.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785622132332421",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Dreamcast - RetroArch Flycast",
-      "steamCategory": "${Sega Dreamcast}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/dreamcast",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}flycast_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI|.m3u|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785622173694320",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Dreamcast - Flycast (Standalone)",
-      "steamCategory": "${Sega Dreamcast - Flycast (Standalone)}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/dreamcast",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "\"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI|.m3u|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserId": "163584525855031650",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Game Gear - RetroArch Genesis Plus GX",
-      "steamCategory": "${Sega Game Gear}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{gamegear/**/!(homebrew),gamegear}/${title}@(.7z|.7Z|.gg|.GG|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785645224239563",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Genesis/Mega Drive - RetroArch Genesis Plus GX",
-      "steamCategory": "${Sega Genesis/Mega Drive}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{genesis/**/!(homebrew),genesis,megadrive/**}/${title}@(.7z|.7Z|.bin|.BIN|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.cue|.CUE)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "164806160364417694",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Genesis/Mega Drive WideScreen - RetroArch Genesis Plus GX",
-      "steamCategory": "${Sega Genesis/Mega Drive WideScreen}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_wide_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/genesiswide",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": true,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.bin|.BIN|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "164806164364417694",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Master System - RetroArch Genesis Plus GX",
-      "steamCategory": "${Sega Master System}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "{mastersystem/**/!(homebrew),mastersystem}/${title}@(.7z|.7Z|.sms|.SMS|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "16478564523883851",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Model 2 - Model 2 Emulator",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${Sega Model 2}",
-      "romDirectory": "${romsdirglobal}/model2/roms",
-      "executableArgs": "\"${fileName}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/model-2-emulator.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "switch_pro": null,
-          "neptune": {
-              "title": "EmuDeck - Steam Deck Frontend",
-              "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
-              "profileType": "template"
-          },
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "169890088467987948",
-      "version": 17,
-      "disabled": false,
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Model 3 - Supermodel",
-      "steamCategory": "${Sega Model 3 - Supermodel}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/model3",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "\"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "switch_pro": null,
-          "neptune": {
-              "title": "Gamepad with Mouse Trackpad",
-              "mappingId": "controller_neptune_gamepad+mouse.vdf",
-              "profileType": "template"
-          },
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/supermodel.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserId": "163584525855031651",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Saturn - RetroArch Beetle",
-      "steamCategory": "${Sega Saturn}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "-L /mednafen_saturn_libretro.so \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "@(saturn|saturnjp)/**/${title}@(.7z|.7Z|.cue|.CUE|.iso|.ISO|.zip|.ZIP|.chd|.CHD|.m3u|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "166502992463815988",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Saturn - Retroarch Kronos",
-      "steamCategory": "${Sega Saturn}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/saturn",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}kronos_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.cue|.CUE|.iso|.ISO|.zip|ZIP|.chd|.m3u|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785645253672240",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sega Saturn - RetroArch Yabause",
-      "steamCategory": "${Sega Saturn - Yabause}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}yabause_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "@(saturn|saturnjp)/**/${title}@(.7z|.7Z|.cue|.CUE|.iso|.ISO|.zip|.ZIP|.chd|.CHD|.m3u|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164795646253672241",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sharp X68000 - RetroArch PX68k",
-      "steamCategory": "${Sharp X68000}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/x68000",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}px68k_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.dim|.zip|.img|.d88|.88d|.hdm|.dup|.2hd|.xdf|.hdf|.cmd|.m3u|.DIM|.ZIP|.IMG|.D88|.88D|.HDM|.DUP|.2HD|.XDF|.HDF|.CMD|.M3U)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785127823332556",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sinclair ZX Spectrum - RetroArch Fuse",
-      "steamCategory": "${Sinclair ZX Spectrum}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/zxspectrum",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fuse_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.tzx|.tap|.z80|.rzx|.scl|.trd|.TZX|.TAP|.Z80|.RZX|.SCL|.TRD|.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164785583010740300",
-      "version": 17,
-      "disabled": false,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "SNK Neo Geo CD - RetroArch FBNeo",
-      "steamCategory": "${SNK Neo Geo CD - FBNeo}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fbneo_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": true,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "@(neogeocd|neogeocdjp)/**/${title}@(.chd|.CHD)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "164824417216097457",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "SNK Neo Geo CD - MAME (Standalone)",
-      "steamDirectory": "${steamdirglobal}",
-      "steamCategory": "${SNK Neo Geo CD}",
-      "romDirectory": "${romsdirglobal}",
-      "executableArgs": "neocdz -cdrm \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "steamInputEnabled": "1",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "drmProtect": false,
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "@(neogeocd|neogeocdjp)/**/${title}@(.chd|.CHD)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "defaultImage": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "tall": "",
-          "long": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "parserId": "168642641869935597",
-      "version": 17
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "SNK Neo Geo Pocket - RetroArch Beetle NeoPop",
-      "steamCategory": "${SNK Neo Geo Pocket}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/ngp",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_ngp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.ngc|.NGC|.ngp|.NGP|.zip|.ZIP|.npc|.NPC)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785621885441702",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "SNK Neo Geo Pocket Color - RetroArch Beetle NeoPop",
-      "steamCategory": "${SNK Neo Geo Pocket Color}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/ngpc",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_ngp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.ngc|.NGC|.ngp|.NGP|.zip|.ZIP|.npc|.NPC)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785621885441701",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation - DuckStation",
-      "steamCategory": "${Sony PlayStation}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/psx",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-batch -fullscreen \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.cue|.CUE|.img|.IMG|.chd|.CHD|.ecm|.ECM|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/duckstation.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785656699856393",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation - RetroArch Beetle PSX HW",
-      "steamCategory": "${Sony PlayStation - Beetle PSX HW}",
-      "executableArgs": "-L /mednafen_psx_hw_libretro.so \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/psx",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "titleModifier": "${fuzzyTitle}",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": true,
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.ccd|.CCD|.chd|.CHD|.cue|.CUE|.m3u|.M3U|.pbp|.PBP|.toc|.TOC)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "165153198040340580",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation - RetroArch SwanStation",
-      "steamCategory": "${Sony PlayStation - SwanStation}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/psx",
-      "executableArgs": "-L /swanstation_libretro.so \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.ccd|.CCD|.chd|.CHD|.cue|.CUE|.m3u|.M3U|.pbp|.PBP|.toc|.TOC)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "166001743996365855",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation 2 - PCSX2",
-      "steamCategory": "${Sony PlayStation 2}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/ps2",
-      "executableArgs": "-batch -fullscreen \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/pcsx2-qt.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": false
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.bin|.BIN|.chd|.CHD|.cso|.CSO|.dump|.DUMP|.gz|.GZ|.img|.IMG|.iso|.ISO|.mdf|.MDF|.nrg|.NRG)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "164785208872922785",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation 3 - RPCS3 (Extracted ISO/PSN)",
-      "steamCategory": "${Sony PlayStation 3}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/ps3",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "--no-gui \"'${filePath}'\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}/PS3_GAME/USRDIR/@(eboot.bin|EBOOT.BIN|ISO.BIN.EDAT|iso.bin.edat)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${PS3}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785645271669680",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob-regex",
-      "configTitle": "Sony PlayStation 3 - RPCS3 (Installed PKG)",
-      "steamCategory": "${Sony PlayStation 3}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "/run/media/mmcblk0p1/Emulation/storage/rpcs3/dev_hdd0/game",
-      "executableArgs": "--no-gui \"'${filePath}'\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob-regex": "${/(^[NP].+)/}/USRDIR/@(eboot.bin|EBOOT.BIN)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${PSN}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "parserId": "165182011334544893",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation Portable - PPSSPP (Standalone)",
-      "steamCategory": "${Sony PlayStation Portable}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/psp",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-f -g \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.elf|.ELF|.chd|.CHD|.cso|.CSO|.iso|.ISO|.pbp|.PBP|.prx|.PRX)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/ppsspp.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785656634747068",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation Portable - RetroArch PPSSPP",
-      "steamCategory": "${Sony PlayStation Portable - RetroArch PPSSPP}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/psp",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}ppsspp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": true,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.7z|.7Z|.elf|.ELF|.chd|.CHD|.cso|.CSO|.iso|.ISO|.pbp|.PBP|.prx|.PRX)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164785656684747068",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Sony PlayStation Vita - Vita3k (Installed PKG)",
-      "steamCategory": "${Sony PlayStation Vita}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}${/}psvita",
-      "executableArgs": "-Fr \"${/.*[/\\\\]([^/\\\\]+)[/\\\\]/|${filePath}}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/home/deck/Applications/Vita3K/Vita3K",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "**/${title}/@(eboot.bin|EBOOT.BIN)"
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "xbox360": null,
-          "xboxone": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${PSV}",
-          "caseInsensitiveVariables": true,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "166409089761171238",
-      "version": 17,
-      "disabled": false,
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "TIC-80 - Retroarch",
-      "steamCategory": "${TIC-80}",
-      "executableModifier": "\"${exePath}\"",
-      "romDirectory": "${romsdirglobal}/tic80",
-      "steamDirectory": "${steamdirglobal}",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}tic80_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "parserInputs": {
-          "glob": "**/${title}@(.tic|.TIC)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": false
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "executable": {
-          "path": "${retroarchpath}",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserId": "164781111102122397",
-      "version": 17,
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "imageMotionTypes": [
-                  "static"
-              ],
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": []
-          }
-      },
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "Tiger Electronics Game.com - MAME",
-      "steamCategory": "${Tiger Electronics Game.com}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/gamecom",
-      "executableArgs": "gamecom -cartridge1 \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "168540950876229866",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  },
-  {
-      "parserType": "Glob",
-      "configTitle": "VTech V.Smile - MAME",
-      "steamCategory": "${VTech V.Smile}",
-      "steamDirectory": "${steamdirglobal}",
-      "romDirectory": "${romsdirglobal}/vsmile",
-      "executableArgs": "vsmile -cart \"${filePath}\"",
-      "executableModifier": "\"${exePath}\"",
-      "startInDirectory": "",
-      "titleModifier": "${fuzzyTitle}",
-      "imageProviders": [
-          "SteamGridDB"
-      ],
-      "onlineImageQueries": "${${fuzzyTitle}}",
-      "imagePool": "${fuzzyTitle}",
-      "disabled": false,
-      "userAccounts": {
-          "specifiedAccounts": ""
-      },
-      "executable": {
-          "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
-          "shortcutPassthrough": false,
-          "appendArgsToExecutable": true
-      },
-      "parserInputs": {
-          "glob": "${title}@(.zip|.ZIP)"
-      },
-      "titleFromVariable": {
-          "limitToGroups": "${MAME}",
-          "caseInsensitiveVariables": false,
-          "skipFileIfVariableWasNotFound": false,
-          "tryToMatchTitle": true
-      },
-      "fuzzyMatch": {
-          "replaceDiacritics": true,
-          "removeCharacters": true,
-          "removeBrackets": true
-      },
-      "imageProviderAPIs": {
-          "SteamGridDB": {
-              "nsfw": false,
-              "humor": false,
-              "styles": [],
-              "stylesHero": [],
-              "stylesLogo": [],
-              "stylesIcon": [],
-              "imageMotionTypes": [
-                  "static"
-              ]
-          }
-      },
-      "parserId": "168541420924650278",
-      "version": 17,
-      "controllers": {
-          "ps4": null,
-          "ps5": null,
-          "ps5_edge": null,
-          "xbox360": null,
-          "xboxone": null,
-          "xboxelite": null,
-          "switch_joycon_left": null,
-          "switch_joycon_right": null,
-          "switch_pro": null,
-          "neptune": null,
-          "steamcontroller_gordon": null
-      },
-      "defaultImage": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
-      },
-      "localImages": {
-          "long": "",
-          "tall": "",
-          "hero": "",
-          "logo": "",
-          "icon": ""
-      },
-      "steamInputEnabled": "1",
-      "drmProtect": false
-  }
+    {
+        "parserType": "Glob",
+        "configTitle": "Cloud Services - Cloud Services",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/cloud",
+        "executableArgs": "",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "${romsdirglobal}/cloud",
+        "titleModifier": "${fuzzyTitle}",
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "drmProtect": false,
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.sh)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": false,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": {
+                "title": "EmuDeck - Cloud",
+                "mappingId": "emudeck_cloud_controller_config.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "Gamepad with Mouse and Gyro",
+                "mappingId": "gamepad_mouse_gyro.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785598905497513",
+        "version": 22,
+        "steamCategories": [
+            "Cloud Services"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Remote Play Clients - Remote Play Clients",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/remoteplay",
+        "executableArgs": "",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "${romsdirglobal}/remoteplay",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.sh|.AppImage)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": false,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164785598905497514",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": {
+                "title": "EmuDeck - Cloud",
+                "mappingId": "emudeck_cloud_controller_config.vdf",
+                "profileType": "template"
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Remote Play Clients"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Amiga - RetroArch PUAE",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/amiga",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598905398120",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Amiga"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Amiga 600 - RetroArch PUAE",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/amiga600",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598905398121",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Amiga 600"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Amiga 1200 - RetroArch PUAE",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/amiga1200",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598905398122",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Amiga 1200"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Amiga CD - RetroArch PUAE",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/amigacd32",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}puae_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.adf|.ADF|.adz|.ADZ|.dms|.DMS|.fdi|.FDI|.ipf|.IPF|.hdf|.HDF|.hdz|.HDZ|.lha|.LHA|.slave|.SLAVE|.info|.INFO|.cue|.CUE|.ccd|.CCD|.chd|.CHD|.nrg|.NRG|.mds|.MDS|.iso|.ISO|.uae|.UAE|.m3u|.M3U|.zip|.ZIP|.7z|.7Z)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598905398123",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Amiga CD"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Amstrad CPC - RetroArch Caprice32",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/amstradcpc",
+        "executableArgs": "-L /cap32_libretro.so \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.7z|.7Z|.cdt|.CDT|.dsk|.DSK|.sna|.SNA|.tap|.TAP|.voc|.VOC|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "166486574949993186",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Amstrad CPC"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - Atomiswave - Flycast (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/atomiswave",
+        "executableArgs": "\"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785622173694321",
+        "version": 22,
+        "disabled": false,
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - Atomiswave - Flycast (Standalone)"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - MAME (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/arcade",
+        "executableArgs": " \"${fileName}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "165964954316677671",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - NAOMI - RetroArch Flycast",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/naomi",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}flycast_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "165768545254166037",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - NAOMI"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - NAOMI - Flycast (Standalone)",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/naomi",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "\"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserId": "164285091855061150",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - NAOMI - Flycast (Standalone)"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - NAOMI 2 - Flycast (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/naomi2",
+        "executableArgs": "\"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.bin|.BIN|.dat|.DAT|.elf|.ELF|.lst|.LST|.7z|.7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785622173694322",
+        "version": 22,
+        "disabled": false,
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - NAOMI 2 - Flycast (Standalone)"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - RetroArch FBNeo",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fbneo_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/fbneo",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(7z|7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "164824416516097457",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - FBNeo"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - RetroArch MAME 2003 Plus",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/mame",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mame2003_plus_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785580134372556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - MAME 2003 Plus"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - RetroArch MAME 2010",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/mame",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mame2010_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164585567134532556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - MAME 2010"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Arcade - RetroArch MAME Current",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/arcade",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mame_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785567134372556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Arcade - MAME Current"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Atari 2600 - RetroArch Stella",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/atari2600",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}stella_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.a26|.A26|.bin|.BIN|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785583010740299",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Atari 2600"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Atari Jaguar - BigPEmu Proton",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "\"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/bigpemu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "@(atarijaguar|atarijaguarcd)/**/${title}@(j64|.J64|.cof|.COF|.rom|.ROM|.jag|.JAG|.abs|.ABS|.zip|.ZIP|.cue|.CUE|.cdi|.CDI)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164824416518097459",
+        "version": 22,
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Atari Jaguar"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Atari Jaguar - RetroArch Virtual Jaguar",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/atarijaguar",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}virtualjaguar_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.j64|.J64|.jag|.JAG|.rom|.ROM|.abs|.ABS|.cof|.COF|.bin|.BIN|.prg|.PRG|.7z|.7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "16476758151010299",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Atari Jaguar"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Atari Lynx - RetroArch Beetle Handy",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/atarilynx",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_lynx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.lnx|.LNX|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785590686474494",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Atari Lynx"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Bandai WonderSwan - RetroArch Beetle Cygne",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/wonderswan",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_wswan_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785595449272607",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Bandai WonderSwan"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Bandai WonderSwan Color - RetroArch Beetle Cygne",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/wonderswancolor",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_wswan_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785595449272606",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Bandai WonderSwan Color"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Commodore 16 - RetroArch VICE",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/c16",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_xplus4_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.d64|.D64|.d71|.D71|.d80|.D80|.d81|.D81|.d82|.D82|.g64|.G64|.g41|.G41|.x64|.X64|.t64|.T64|.tap|.TAP|.prg|.PRG|.p00|.P00|.crt|.CRT|.bin|.BIN|.d6z|.D6Z|.d7z|.D7Z|.d8z|.D8Z|.g6z|.G6Z|.g4z|.G4Z|.x6z|.X6Z|.cmd|.CMD|.m3u|.M3U|.vsf|.VSF|.nib|.NIB|.nbz|.NBZ|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164712598905497531",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Commodore 16"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Commodore 64 - RetroArch VICE",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/c64",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_x64_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.d64|.D64|.d71|.D71|.d80|.D80|.d81|.D81|.d82|.D82|.g64|.G64|.g41|.G41|.x64|.X64|.t64|.T64|.tap|.TAP|.prg|.PRG|.p00|.P00|.crt|.CRT|.bin|.BIN|.d6z|.D6Z|.d7z|.D7Z|.d8z|.D8Z|.g6z|.G6Z|.g4z|.G4Z|.x6z|.X6Z|.cmd|.CMD|.m3u|.M3U|.vsf|.VSF|.nib|.NIB|.nbz|.NBZ|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164785598905497512",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Commodore 64"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Commodore VIC-20 - RetroArch VICE",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/vic20",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vice_xvic_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.d64|.d6z|.d71|.d7z|.d80|.d81|.d82|.d8z|.g64|.g6z|.g41|.g4z|.x64|.x6z|.nib|.nbz|.d2m|.d4m|.t64|.tap|.tcrt|.prg|.p00|.crt|.bin|.cmd|.m3u|.vfl|.vsf|.zip|.7z|.gz|.20|.40|.60|.a0|.b0|.rom|.D64|.D6Z|.D71|.D7Z|.D80|.D81|.D82|.D8Z|.G64|.G6Z|.G41|.G4Z|.X64|.X6Z|.NIB|.NBZ|.D2M|.D4M|.T64|.TAP|.TCRT|.PRG|.P00|.CRT|.BIN|.CMD|.M3U|.VFL|.VSF|.ZIP|.7Z|.GZ|.20|.40|.60|.A0|.B0|.ROM|)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785127820983556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Commodore VIC-20"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Desktop Applications",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "",
+            "shortcutPassthrough": true,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "{desktop/**/!(cloud|remoteplay),desktop}/${title}@(sh|.SH|.desktop|.DESKTOP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "171773288577350796",
+        "version": 22,
+        "steamCategories": [
+            "Desktop Applications"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "DooM - RetroArch PrBoom",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/doom",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}prboom_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.wad|.WAD|.iwad|.IWAD|.pwad|.PWAD|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785092749272606",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "DooM"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "DOS - RetroArch DOSBox Pure",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}dosbox_pure_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/dos",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "165155371770791847",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "DOS"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Intellivision - RetroArch FreeIntv",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/intellivision",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}freeintv_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.int|.INT|.bin|.BIN|.rom|.ROM|.7z|.7Z|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164789998905398117",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Mattel Electronics Intellivision"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Microsoft Xbox 360 - Xenia",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/xbox360",
+        "executableArgs": "\"Z:${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "{roms/**/!(xbla),roms}/**/${title}@(.iso|.ISO|.xex|.XEX|.zar|.ZAR)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "animated"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "135113607715086732",
+        "version": 22,
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Microsoft Xbox 360"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Microsoft Xbox 360 - Xbox Live Arcade - Xenia",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/xbox360/roms/",
+        "executableArgs": "\"Z:${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/xenia.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "xbla/**/${title}"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "167851246183635366",
+        "version": 22,
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Microsoft Xbox 360 - Xbox Live Arcade"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Microsoft Xbox - Xemu",
+        "executableArgs": " -full-screen -dvd_path \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/xbox",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/xemu-emu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.iso|.ISO)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "165103607715056732",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Microsoft Xbox"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "NEC PC-98 - RetroArch NP2kai",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/pc98",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}np2kai_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.d98|.zip|.98d|.fdi|.fdd|.2hd|.tfd|.d88|.88d|.hdm|.xdf|.dup|.cmd|.hdi|.thd|.nhd|.hdd|.hdn|.D98|.ZIP|.98D|.FDI|.FDD|.2HD|.TFD|.D88|.88D|.HDM|.XDF|.DUP|.CMD|.HDI|.THD|.NHD|.HDD|.HDN)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "1647850989120983556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "NEC PC-98"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "NEC PC Engine/TurboGrafx 16 CD - RetroArch Beetle PCE",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pce_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "@(pcenginecd|tg-cd)/**/${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "165856080826916450",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "NEC PC Engine/TurboGrafx 16 CD"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "NEC PC Engine/TurboGrafx 16 - RetroArch Beetle PCE",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pce_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "@(pcengine|tg16)/**/${title}@(.7z|.7Z|.bin|.BIN|.pce|.PCE|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "165855998563219386",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "NEC PC Engine/TurboGrafx 16"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "PCFX - RetroArch Beetle PC-FX",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/pcfx",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_pcfx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.ccd|.CCD|.chd|.CHD|.cue|CUE|.m3u|.M3U|.toc|.TOC|.7z|.7Z|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164789998905398116",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "NEC PC-FX"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo 3DS - RetroArch Citra",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/n3ds",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}citra_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.3ds|.3DS|.3dsx|.3DSX|.app|.APP|.axf|.AXF|.cii|.CII|.cxi|.CXI|.elf|.ELF|.cci|.CCI)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164680998105308116",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo 3DS - RetroArch Citra"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo 3DS - Citra",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/n3ds",
+        "steamCategories": [
+            "Nintendo 3DS"
+        ],
+        "executableArgs": " \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/citra.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.3ds|.3DS|.3dsx|.3DSX|.app|.APP|.axf|.AXF|.cii|.CII|.cxi|.CXI|.elf|.ELF|.cci|.CCI)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "16478559884003904",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo 64 - RetroArch Mupen64Plus Next",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/n64",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mupen64plus_next_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.bin|.BIN|.n64|.N64|.ndd|.NDD|.u1|.U1|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598905398114",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo 64"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo 64 - Rosalie's Mupen GUI",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "--fullscreen --nogui --quit-after-emulation \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rosaliesmupengui.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "@(n64|n64dd)/**/${title}@(.7z|.7Z|.bin|.BIN|.n64|.N64|.ndd|.NDD|.u1|.U1|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "167184642099963041",
+        "version": 22,
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo 64 - Rosalie's Mupen GUI"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo DS - RetroArch melonDS DS",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/nds",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}melondsds_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "drmProtect": false,
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.dsi|.DSI|.ids|.IDS|.nds|.NDS|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164843694520657522",
+        "version": 22,
+        "steamCategories": [
+            "Nintendo DS"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo DS - melonDS (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/nds",
+        "steamCategories": [
+            "Nintendo DS - melonDS (Standalone)"
+        ],
+        "executableArgs": "\"${filePath}\" -f",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/melonds.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.nds|.NDS|.app|.APP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164823604520657524",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo DS - RetroArch melonDS (Legacy)",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}melonds_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/nds",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": true,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.nds|.NDS|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "164823604520657522",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo DS - RetroArch melonDS (Legacy)"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy Advance - RetroArch mGBA",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mgba_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{gba/**/!(homebrew),gba}/${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598920514822",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Game Boy Advance"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy Advance - mGBA (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "steamCategories": [
+            "Nintendo Game Boy Advance - mGBA (Standalone)"
+        ],
+        "executableArgs": "-f \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "{gba/**/!(homebrew),gba}/${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785621855061652",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy Color - RetroArch Gambatte",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598936495323",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Game Boy Color"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy Color - mGBA (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "steamCategories": [
+            "Nintendo Game Boy Color - mGBA (Standalone)"
+        ],
+        "executableArgs": "-f \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785621855061661",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy Color - RetroArch SameBoy",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{gbc/**/!(homebrew),gbc}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785590985613234",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Game Boy Color - SameBoy"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy - RetroArch Gambatte",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{gb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785598952083233",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Game Boy"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy - mGBA (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "steamCategories": [
+            "Nintendo Game Boy - mGBA (Standalone)"
+        ],
+        "executableArgs": "-f \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mgba.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "{gb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164385421865061350",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Game Boy - RetroArch SameBoy",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "parserInputs": {
+            "glob": "{gb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785590985613233",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Game Boy - SameBoy"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo GameCube - Dolphin",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/gc",
+        "executableArgs": "vblank_mode=0 %command% -b -e \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.json|.JSON|.nkit.iso|.NKIT.ISO|.nkit.gcz|.NKIT.GCZ|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.m3u|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164770728884890304",
+        "version": 22,
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo GameCube"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Entertainment System - RetroArch Mesen",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{nes/**/!(homebrew),nes,famicom/**}/${title}@(.7z|.7Z|.nes|.NES|.fds|.FDS|.unf|.UNF|.unif|.UNIF|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785621824841888",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Entertainment System"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Metroid Prime Trilogy - PrimeHack",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/primehacks",
+        "executableArgs": "vblank_mode=0 %command% run io.github.shiiion.primehack -b -e \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/primehack.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.json|.JSON|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.WBFS)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164770728884890305",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Wii"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Super Game Boy - RetroArch Mesen S",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen-s_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{sgb/**/!(homebrew),gb}/${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.sgb|.SGB|.dmg|.DMG|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "16472550495204231",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Super Game Boy"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo SNES (Super Nintendo) - RetroArch Snes9x",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}snes9x_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{snes/**/!(homebrew),snes,snesna/**}/${title}@(.7z|.7Z|.bs|.BS|.fig|.FIG|.sfc|.SFC|.smc|.SMC|.swc|.SWC|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785621840217949",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo SNES (Super Nintendo)"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo SNES (Super Nintendo) HD - RetroArch bsnes-hd",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/sneshd",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}bsnes_hd_beta_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.bs|.BS|.fig|.FIG|.sfc|.SFC|.smc|.SMC|.swc|.SWC|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "166785621840217949",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo SNES (Super Nintendo) HD - bsnes-hd"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Switch - Ryujinx",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/switch",
+        "executableArgs": "--fullscreen \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle} (Ryujinx)",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "disabled": false,
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/ryujinx.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.kip|.KIP|.nca|.NCA|.nro|.NRO|.nso|.NSO|.nsp|.NSP|.nsz|.NSZ|.xci|.XCI)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164788906872922785",
+        "version": 22,
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Switch - Ryujinx"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Switch - Yuzu",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/switch",
+        "executableArgs": "vblank_mode=0 %command% -f -g \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "disabled": true,
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/yuzu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.kip|.KIP|.nca|.NCA|.nro|.NRO|.nso|.NSO|.nsp|.NSP|.xci|.XCI)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785621855061650",
+        "version": 22,
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Switch - Yuzu"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Virtual Boy - RetroArch Beetle VB",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/virtualboy",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_vb_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.vb|.VB|.vboy|.VBOY|.bin|.BIN|.7z|.7Z|.zip|.ZIP)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164789998905398115",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Virtual Boy"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Wii - Dolphin",
+        "executableArgs": "vblank_mode=0 %command% -b -e \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/wii",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/dolphin-emu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.ciso|.CISO|.dol|.DOL|.elf|.ELF|.gcm|.GCM|.gcz|.GCZ|.iso|.ISO|.nkit.iso|.NKIT.ISO|.rvz|.RVZ|.wad|.WAD|.wia|.WIA|.wbfs|.m3u|.M3U|.json|.JSON)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "switch_pro": null,
+            "neptune": {
+                "title": "Gamepad with Mouse Trackpad",
+                "mappingId": "controller_neptune_gamepad+mouse.vdf",
+                "profileType": "template"
+            },
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null
+        },
+        "parserId": "164770823452964732",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Nintendo Wii"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Wii U - Cemu Native (.rpx)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/wiiu/roms/",
+        "steamCategories": [
+            "Nintendo Wii U - Cemu Native"
+        ],
+        "executableArgs": "vblank_mode=0 %command% -f -g \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "${title}/**/*.rpx"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",
+            "hero": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/hero.png",
+            "logo": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/logo.png",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "166758881839575782",
+        "version": 22
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Wii U - Cemu Native (.wud, .wux, .wua)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/wiiu/roms/",
+        "steamCategories": [
+            "Nintendo Wii U - Cemu Native"
+        ],
+        "executableArgs": "vblank_mode=0 %command% -f -g \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.elf|.ELF|.tmd|.TMD|.wua|.WUA|.wud|.WUD|.wuhb|.WUHB|.wux|.WUX)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",
+            "hero": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/hero.png",
+            "logo": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/logo.png",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "166758882107057128",
+        "version": 22
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Wii U - Cemu Proton (.rpx)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/wiiu/roms/",
+        "steamCategories": [
+            "Nintendo Wii U - Cemu Proton"
+        ],
+        "executableArgs": "vblank_mode=0 %command% -w -f -g \"Z:${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle} (Proton)",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "${title}/**/*.rpx"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": {
+                "title": "Gamepad",
+                "mappingId": "controller_switch_joycon_left_gamepad_joystick.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_right": {
+                "title": "Gamepad",
+                "mappingId": "controller_switch_joycon_right_gamepad_joystick.vdf",
+                "profileType": "template"
+            },
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164824416516097458",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Nintendo Wii U - Cemu Proton (.wud, .wux, .wua)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/wiiu/roms/",
+        "steamCategories": [
+            "Nintendo Wii U - Cemu Proton"
+        ],
+        "executableArgs": "vblank_mode=0 %command% -w -f -g \"Z:${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle} (Proton)",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/cemu.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.elf|.ELF|.tmd|.TMD|.wua|.WUA|.wud|.WUD|.wuhb|.WUHB|.wux|.WUX)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps4.vdf",
+                "profileType": "template"
+            },
+            "ps5": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5.vdf",
+                "profileType": "template"
+            },
+            "ps5_edge": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xbox360.vdf",
+                "profileType": "template"
+            },
+            "xboxone": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxone.vdf",
+                "profileType": "template"
+            },
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_switch_pro.vdf",
+                "profileType": "template"
+            },
+            "neptune": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164824416518097458",
+        "version": 22,
+        "disabled": true
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Panasonic 3DO - RetroArch Opera",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/3do",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}opera_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.iso|.ISO|.bin|.BIN|.chd|.CHD|.cue|.cue)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${3DO}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785580114332556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Panasonic 3DO"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Philips CD-i - RetroArch SAME CDi",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/cdimono1",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}same_cdi_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "drmProtect": false,
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.iso|.ISO|.chd|.CHD)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "164785621902122397",
+        "version": 22,
+        "steamCategories": [
+            "Philips CD-i"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Philips CD-i - MAME (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/cdimono1",
+        "executableArgs": "cdimono1 -cdrom \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "drmProtect": false,
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.chd|.CHD)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": {
+                "title": "Gamepad with Mouse Trackpad",
+                "mappingId": "controller_neptune_gamepad+mouse.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "168541242505111076",
+        "version": 22,
+        "disabled": true,
+        "steamCategories": [
+            "Philips CD-i - MAME"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Pico 8 - RetroArch Retro8",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/pico8",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}retro8_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.zip|.ZIP|.p8|.P8|.png|.PNG)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserId": "164785621902122396",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Pico 8"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "RPG Maker - RetroArch EasyRPG",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/easyrpg",
+        "executableArgs": "-L /easyrpg_libretro.so \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${title}}",
+        "imagePool": "${title}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "${title}/*@(.ldb|.easyrpg)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "167174183584229566",
+        "version": 22,
+        "disabled": false,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "RPG Maker"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "ScummVM - ScummVM",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/scummvm",
+        "executableArgs": "--path=\"${filePath}\" --auto-detect",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/scummvm.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "controllers": {
+            "switch_pro": null,
+            "neptune": {
+                "title": "Gamepad with Mouse Trackpad",
+                "mappingId": "controller_neptune_gamepad+mouse.vdf",
+                "profileType": "template"
+            },
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null
+        },
+        "parserInputs": {
+            "glob": "${title}.scummvm"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "166399570436769358",
+        "version": 22,
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "ScummVM"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega 32X - RetroArch PicoDrive",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/sega32x",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}picodrive_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785621902111196",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega 32X"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega CD/Mega CD - RetroArch Genesis Plus GX",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "@(segacd|megacd)/**/${title}@(.m3u|.M3U|.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785622132332421",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega CD/Mega CD"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Dreamcast - RetroArch Flycast",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/dreamcast",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}flycast_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI|.m3u|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785622173694320",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Dreamcast"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Dreamcast - Flycast (Standalone)",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/dreamcast",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "\"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.cdi|.CDI|.chd|.CHD|.cue|.CUE|.gdi|.GDI|.m3u|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/flycast.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserId": "163584525855031650",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Dreamcast - Flycast (Standalone)"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Game Gear - RetroArch Genesis Plus GX",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{gamegear/**/!(homebrew),gamegear}/${title}@(.7z|.7Z|.gg|.GG|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785645224239563",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Game Gear"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Genesis/Mega Drive - RetroArch Genesis Plus GX",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{genesis/**/!(homebrew),genesis,megadrive/**}/${title}@(.7z|.7Z|.bin|.BIN|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.cue|.CUE)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "164806160364417694",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Genesis/Mega Drive"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Genesis/Mega Drive WideScreen - RetroArch Genesis Plus GX",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_wide_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/genesiswide",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": true,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.bin|.BIN|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "164806164364417694",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Genesis/Mega Drive WideScreen"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Master System - RetroArch Genesis Plus GX",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}genesis_plus_gx_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "{mastersystem/**/!(homebrew),mastersystem}/${title}@(.7z|.7Z|.sms|.SMS|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "16478564523883851",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Master System"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Model 2 - Model 2 Emulator",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/model2/roms",
+        "steamCategories": [
+            "Sega Model 2"
+        ],
+        "executableArgs": "\"${fileName}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/model-2-emulator.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_ps5_dualsense_edge.vdf",
+                "profileType": "template"
+            },
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": {
+                "title": "EmuDeck - Controller Hotkeys",
+                "mappingId": "emudeck_controller_xboxelite.vdf",
+                "profileType": "template"
+            },
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamdeck.vdf",
+                "profileType": "template"
+            },
+            "steamcontroller_gordon": {
+                "title": "EmuDeck - Frontend Controller Hotkeys",
+                "mappingId": "emudeck_frontend_controller_steamcontroller.vdf",
+                "profileType": "template"
+            }
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "169890088467987948",
+        "version": 22
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Model 3 - Supermodel",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/model3",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "\"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "switch_pro": null,
+            "neptune": {
+                "title": "Gamepad with Mouse Trackpad",
+                "mappingId": "controller_neptune_gamepad+mouse.vdf",
+                "profileType": "template"
+            },
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/supermodel.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserId": "163584525855031651",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Model 3 - Supermodel"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Saturn - RetroArch Beetle",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "-L /mednafen_saturn_libretro.so \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "@(saturn|saturnjp)/**/${title}@(.7z|.7Z|.cue|.CUE|.iso|.ISO|.zip|.ZIP|.chd|.CHD|.m3u|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "166502992463815988",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Saturn"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Saturn - Retroarch Kronos",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/saturn",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}kronos_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.cue|.CUE|.iso|.ISO|.zip|ZIP|.chd|.m3u|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785645253672240",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Saturn"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sega Saturn - RetroArch Yabause",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}yabause_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "@(saturn|saturnjp)/**/${title}@(.7z|.7Z|.cue|.CUE|.iso|.ISO|.zip|.ZIP|.chd|.CHD|.m3u|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164795646253672241",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sega Saturn - Yabause"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sharp X68000 - RetroArch PX68k",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/x68000",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}px68k_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.dim|.zip|.img|.d88|.88d|.hdm|.dup|.2hd|.xdf|.hdf|.cmd|.m3u|.DIM|.ZIP|.IMG|.D88|.88D|.HDM|.DUP|.2HD|.XDF|.HDF|.CMD|.M3U)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785127823332556",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sharp X68000"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sinclair ZX Spectrum - RetroArch Fuse",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/zxspectrum",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fuse_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.tzx|.tap|.z80|.rzx|.scl|.trd|.TZX|.TAP|.Z80|.RZX|.SCL|.TRD|.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164785583010740300",
+        "version": 22,
+        "disabled": false,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sinclair ZX Spectrum"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "SNK Neo Geo CD - RetroArch FBNeo",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}fbneo_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": true,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "@(neogeocd|neogeocdjp)/**/${title}@(.chd|.CHD)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "164824417216097457",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "SNK Neo Geo CD - FBNeo"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "SNK Neo Geo CD - MAME (Standalone)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}",
+        "executableArgs": "neocdz -cdrm \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "steamInputEnabled": "1",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "drmProtect": false,
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "@(neogeocd|neogeocdjp)/**/${title}@(.chd|.CHD)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "defaultImage": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "tall": "",
+            "long": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "parserId": "168642641869935597",
+        "version": 22,
+        "steamCategories": [
+            "SNK Neo Geo CD"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "SNK Neo Geo Pocket - RetroArch Beetle NeoPop",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/ngp",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_ngp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.ngc|.NGC|.ngp|.NGP|.zip|.ZIP|.npc|.NPC)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785621885441702",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "SNK Neo Geo Pocket"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "SNK Neo Geo Pocket Color - RetroArch Beetle NeoPop",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/ngpc",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_ngp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.ngc|.NGC|.ngp|.NGP|.zip|.ZIP|.npc|.NPC)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785621885441701",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "SNK Neo Geo Pocket Color"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation - DuckStation",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/psx",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-batch -fullscreen \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.cue|.CUE|.img|.IMG|.chd|.CHD|.ecm|.ECM|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/duckstation.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785656699856393",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation - RetroArch Beetle PSX HW",
+        "executableArgs": "-L /mednafen_psx_hw_libretro.so \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/psx",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "titleModifier": "${fuzzyTitle}",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": true,
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.ccd|.CCD|.chd|.CHD|.cue|.CUE|.m3u|.M3U|.pbp|.PBP|.toc|.TOC)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "165153198040340580",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation - Beetle PSX HW"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation - RetroArch SwanStation",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/psx",
+        "executableArgs": "-L /swanstation_libretro.so \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.ccd|.CCD|.chd|.CHD|.cue|.CUE|.m3u|.M3U|.pbp|.PBP|.toc|.TOC)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "166001743996365855",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation - SwanStation"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation 2 - PCSX2",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/ps2",
+        "executableArgs": "-batch -fullscreen \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/pcsx2-qt.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": false
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.bin|.BIN|.chd|.CHD|.cso|.CSO|.dump|.DUMP|.gz|.GZ|.img|.IMG|.iso|.ISO|.mdf|.MDF|.nrg|.NRG)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "164785208872922785",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation 2"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation 3 - RPCS3 (Extracted ISO/PSN)",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/ps3",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "--no-gui \"'${filePath}'\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}/PS3_GAME/USRDIR/@(eboot.bin|EBOOT.BIN|ISO.BIN.EDAT|iso.bin.edat)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${PS3}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785645271669680",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation 3"
+        ]
+    },
+    {
+        "parserType": "Glob-regex",
+        "configTitle": "Sony PlayStation 3 - RPCS3 (Installed PKG)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "/run/media/mmcblk0p1/Emulation/storage/rpcs3/dev_hdd0/game",
+        "executableArgs": "--no-gui \"'${filePath}'\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/rpcs3.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob-regex": "${/(^[NP].+)/}/USRDIR/@(eboot.bin|EBOOT.BIN)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${PSN}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "parserId": "165182011334544893",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation 3"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation Portable - PPSSPP (Standalone)",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/psp",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-f -g \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.elf|.ELF|.chd|.CHD|.cso|.CSO|.iso|.ISO|.pbp|.PBP|.prx|.PRX)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/ppsspp.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785656634747068",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation Portable"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation Portable - RetroArch PPSSPP",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/psp",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}ppsspp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": true,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.7z|.7Z|.elf|.ELF|.chd|.CHD|.cso|.CSO|.iso|.ISO|.pbp|.PBP|.prx|.PRX)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164785656684747068",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation Portable - RetroArch PPSSPP"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation Vita - Vita3k (Installed PKG)",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}${/}psvita",
+        "executableArgs": "-Fr \"${/.*[/\\\\]([^/\\\\]+)[/\\\\]/|${filePath}}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/home/deck/Applications/Vita3K/Vita3K",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "**/${title}/@(eboot.bin|EBOOT.BIN)"
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "xbox360": null,
+            "xboxone": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${PSV}",
+            "caseInsensitiveVariables": true,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "166409089761171238",
+        "version": 22,
+        "disabled": false,
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Sony PlayStation Vita"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "TIC-80 - Retroarch",
+        "executableModifier": "\"${exePath}\"",
+        "romDirectory": "${romsdirglobal}/tic80",
+        "steamDirectory": "${steamdirglobal}",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}tic80_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "**/${title}@(.tic|.TIC)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "executable": {
+            "path": "${retroarchpath}",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserId": "164781111102122397",
+        "version": 22,
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": []
+            }
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "TIC-80"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "Tiger Electronics Game.com - MAME",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/gamecom",
+        "executableArgs": "gamecom -cartridge1 \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "168540950876229866",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "Tiger Electronics Game.com"
+        ]
+    },
+    {
+        "parserType": "Glob",
+        "configTitle": "VTech V.Smile - MAME",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "${romsdirglobal}/vsmile",
+        "executableArgs": "vsmile -cart \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [
+            "sgdb",
+            "steamCDN"
+        ],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+        "disabled": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "executable": {
+            "path": "/run/media/mmcblk0p1/Emulation/tools/launchers/mame.sh",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "parserInputs": {
+            "glob": "${title}@(.zip|.ZIP)"
+        },
+        "titleFromVariable": {
+            "limitToGroups": "${MAME}",
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": false,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ]
+            }
+        },
+        "parserId": "168541420924650278",
+        "version": 22,
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "defaultImage": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
+        },
+        "localImages": {
+            "long": "",
+            "tall": "",
+            "hero": "",
+            "logo": "",
+            "icon": ""
+        },
+        "steamInputEnabled": "1",
+        "drmProtect": false,
+        "steamCategories": [
+            "VTech V.Smile"
+        ]
+    }
 ]

--- a/functions/ToolScripts/emuDeckSRM.sh
+++ b/functions/ToolScripts/emuDeckSRM.sh
@@ -457,7 +457,7 @@ SRM_addControllerTemplate(){
     echo "Steam install not found"
   fi
 
-  sed -i "s|/home/deck/.steam/steam|${STEAMPATH}|g" "$HOME/.config/steam-rom-manager/userData/controllerTemplates.json"
+  sed -i "s|/home/deck/.local/share/Steam|${STEAMPATH}|g" "$HOME/.config/steam-rom-manager/userData/controllerTemplates.json"
 
 }
 


### PR DESCRIPTION
* Controller templates did not have localization names set properly causing them to unstick in Steam ROM Manager/identify as another controller profile 
    * Updated controllerTemplates.json file to match changes
* Updated Steam path to ~/.local to match new SRM update