### PR TITLE
fix: Ryujinx launcher for Flatpak

### DIFF
--- a/functions/EmuScripts/emuDeckRyujinx.sh
+++ b/functions/EmuScripts/emuDeckRyujinx.sh
@@ -49,7 +49,7 @@ Ryujinx_cleanup(){
 Ryujinx_install(){
     echo "Begin Ryujinx Install"
     local showProgress=$1
-    if installEmuBI "$Ryujinx_emuName" "$(getReleaseURLGH "ryujinx-mirror/ryujinx" "-linux_x64.tar.gz")" "" "tar.gz" "$showProgress"; then
+    if installEmuBI "$Ryujinx_emuName" "$(getReleaseURLGH "ryujinx-mirror/ryujinx" "-linux_x64.tar.gz" "" "ryujinx-")" "" "tar.gz" "$showProgress"; then
         tar -xvf "$HOME/Applications/Ryujinx.tar.gz" -C "$HOME/Applications/" && rm -rf "$HOME/Applications/Ryujinx.tar.gz"
         chmod +x "$HOME/Applications/publish/Ryujinx"
     else

--- a/functions/helperFunctions.sh
+++ b/functions/helperFunctions.sh
@@ -399,6 +399,7 @@ function getLatestReleaseURLGH(){
 	local repository=$1
 	local fileType=$2
 	local fileNameContains=$3
+	local fileNameStartsWith=$4
 	local url
 	#local token=$(tokenGenerator)
 
@@ -407,30 +408,23 @@ function getLatestReleaseURLGH(){
 	fi
 
 	curl -fSs "$url" | \
-		jq -r '[ .assets[] | select(.name | contains("'"$fileNameContains"'") and endswith("'"$fileType"'")).browser_download_url ][0] // empty'
+		jq -r '[ .assets[] | select(.name | contains("'"$fileNameContains"'") and startswith("'"$fileNameStartsWith"'") and endswith("'"$fileType"'")).browser_download_url ][0] // empty'
 }
 
 function getReleaseURLGH(){
 	local repository=$1
 	local fileType=$2
-	local url
 	local fileNameContains=$3
+	local fileNameStartsWith=$4
+	local url
 	#local token=$(tokenGenerator)
-
-# 	if [ "$system" == "darwin" ]; then
-# 		fileType="dmg"
-# 	fi
-#
-# 	if [ "$system" == "darwin" ]; then
-# 		fileType="dmg"
-# 	fi
 
 	if [ "$url" == "" ]; then
 		url="https://api.github.com/repos/$repository/releases"
 	fi
 
 	curl -fSs "$url" | \
-		jq -r '[ .[].assets[] | select(.name | contains("'"$fileNameContains"'") and endswith("'"$fileType"'")).browser_download_url ][0] // empty'
+		jq -r '[ .[].assets[] | select(.name | contains("'"$fileNameContains"'") and startswith("'"$fileNameStartsWith"'") and endswith("'"$fileType"'")).browser_download_url ][0] // empty'
 }
 
 function linkToSaveFolder(){

--- a/tools/launchers/ryujinx.sh
+++ b/tools/launchers/ryujinx.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 source $HOME/.config/EmuDeck/backend/functions/all.sh
 emulatorInit "ryujinx"
-emuName="Ryujinx.sh" #parameterize me
-emufolder="$HOME/Applications/publish" # has to be applications for ES-DE to find it
+emuName="Ryujinx" #parameterize me
+emufolder="$HOME/Applications/publish" # has to be here for ES-DE to find it
 
 #initialize execute array
 exe=()
 
 #find full path to emu executable
-exe_path=$(find "$emufolder" -iname "${emuName}" | sort -n | cut -d' ' -f 2- | tail -n 1 2>/dev/null)
+exe_path=$(find "$emufolder" -iname "${emuName}.sh" | sort -n | cut -d' ' -f 2- | tail -n 1 2>/dev/null)
 
 #if appimage doesn't exist fall back to flatpak.
 if [[ -z "$exe_path" ]]; then


### PR DESCRIPTION
- fix launcher not finding flatpak
- improve finding correct GH asset (fileNamestartsWith) - different asset order on GH would download wrong one as they all end the same)