### PR TITLE
Fix install.sh to run prerequisite checks on all distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 linuxID=$(lsb_release -si)
 sandbox=""
 
-if [ "$linuxID" == "ChimeraOS" ] || [ "$linuxID" == "SteamOS" ]; then
+if [ "$linuxID" == "SteamOS" ]; then
     echo "installing EmuDeck"
 else
     zenityAvailable=$(command -v zenity &> /dev/null  && echo true)

--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,10 @@
 
 linuxID=$(lsb_release -si)
 sandbox=""
-if [ $linuxID != "ChimeraOS" ]; then
 
-echo "installing EmuDeck"
-
-elif [ $linuxID != "SteamOS" ]; then
-
-
+if [ "$linuxID" == "ChimeraOS" ] || [ "$linuxID" == "SteamOS" ]; then
+    echo "installing EmuDeck"
+else
     zenityAvailable=$(command -v zenity &> /dev/null  && echo true)
 
     if [[ $zenityAvailable = true ]];then


### PR DESCRIPTION
Fixes #1346

As far as I can tell, the existing logic means that prerequisite checks would only run on ChimeraOS, which doesn't seem like the desired behavior (the "not SteamOS" logic short-circuits everything else away and just prints "installing EmuDeck").

So the logic after this should be "everything except for SteamOS installs prereqs, including ChimeraOS". Let me know if that's not correct.

Could be totally wrong on this, but the prereq checks didn't run for me on Arch before this change and now run after! Happy to adjust if needed.