### PR TITLE
Couple of fixes (ShadPS4, Ryujinx, Xenia)

### DIFF
--- a/configs/steam-deck-romate/userConfigurations.json
+++ b/configs/steam-deck-romate/userConfigurations.json
@@ -1048,7 +1048,7 @@
   {
     "id": "166409089761171238",
     "executable": {
-      "path": "\"/home/deck/.config/EmuDeck/Emulators/Vita3K/Vita3K\" -Fr \"${/.*[/\\\\]([^/\\\\]+)[/\\\\]/|${filePath}}\"",
+      "path": "\"/home/deck/Applications/Vita3K/Vita3K\" -Fr \"${/.*[/\\\\]([^/\\\\]+)[/\\\\]/|${filePath}}\"",
       "arguments": ""
     },
     "romDirectory": "roms/psvita",

--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_psvita-vita3k-pkg.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_psvita-vita3k-pkg.json
@@ -15,7 +15,7 @@
     "specifiedAccounts": ""
   },
   "executable": {
-    "path": "/home/deck/.config/EmuDeck/Emulators/Vita3K/Vita3K",
+    "path": "/home/deck/Applications/Vita3K/Vita3K",
     "shortcutPassthrough": false,
     "appendArgsToExecutable": true
   },

--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -9491,7 +9491,7 @@
             ]
         },
         "executable": {
-            "path": "/home/deck/.config/EmuDeck/Emulators/Vita3K/Vita3K",
+            "path": "/home/deck/Applications/Vita3K/Vita3K",
             "shortcutPassthrough": false,
             "appendArgsToExecutable": true
         },

--- a/functions/EmuScripts/emuDeckRyujinx.sh
+++ b/functions/EmuScripts/emuDeckRyujinx.sh
@@ -49,7 +49,7 @@ Ryujinx_cleanup(){
 Ryujinx_install(){
     echo "Begin Ryujinx Install"
     local showProgress=$1
-    if installEmuBI "$Ryujinx_emuName" "$(getReleaseURLGH "Ryubing/Ryujinx" "-linux_x64.tar.gz")" "" "tar.gz" "$showProgress"; then
+    if installEmuBI "$Ryujinx_emuName" "$(getReleaseURLGH "Ryubing/Ryujinx" "-linux_x64.tar.gz" "" "" "nogui")" "" "tar.gz" "$showProgress"; then
         mkdir -p "$HOME/Applications/publish"
         tar -xvf "$HOME/Applications/Ryujinx.tar.gz" -C "$HOME/Applications" && rm -rf "$HOME/Applications/Ryujinx.tar.gz"
         chmod +x "$HOME/Applications/publish/Ryujinx"

--- a/functions/EmuScripts/emuDeckShadPS4.sh
+++ b/functions/EmuScripts/emuDeckShadPS4.sh
@@ -52,8 +52,8 @@ ShadPS4_setEmulationFolder(){
 
     # setup bios link for LLE sys_modules (optional)
     mkdir -p "${biosPath}/shadps4/"
-    mkdir -p "ShadPS4_dir/sys_modules"
-    ln -sn "ShadPS4_dir/sys_modules" "${biosPath}/shadps4/sys_modules"
+    mkdir -p "$ShadPS4_dir/sys_modules"
+    ln -sn "$ShadPS4_dir/sys_modules" "${biosPath}/shadps4/sys_modules"
 
     echo "ShadPS4 Path Config Completed"
 }

--- a/functions/EmuScripts/emuDeckShadPS4.sh
+++ b/functions/EmuScripts/emuDeckShadPS4.sh
@@ -5,6 +5,7 @@
 # Variables
 
 ShadPS4_emuName="ShadPS4"
+ShadPS4_emuFileName="Shadps4-qt"
 ShadPS4_emuType="$emuDeckEmuTypeAppImage"
 ShadPS4_emuPath="$HOME/Applications"
 ShadPS4_dir="$HOME/.local/share/shadPS4"
@@ -16,17 +17,20 @@ ShadPS4_cleanup(){
 
 # TODO: Install Flatpak from https://github.com/shadps4-emu/shadPS4-flatpak
 ShadPS4_install(){
-  echo "Begin ShadPS4 Install"
-  local showProgress=$1
+    echo "Begin ShadPS4 Install"
+    local showProgress=$1
 
-  if installEmuAI "$ShadPS4_emuName" "" "$(getReleaseURLGH "shadps4-emu/shadPS4" "zip" "linux-qt")" "" "zip" "emulator" "$showProgress"; then
-    unzip -o "$HOME/Applications/ShadPS4.zip" -d "$ShadPS4_emuPath" && rm -rf "$HOME/Applications/ShadPS4.zip"
-    chmod +x "$ShadPS4_emuPath/publish/Shadps4-qt.AppImage"
-  else
-    return 1
-  fi
+    if safeDownload "$ShadPS4_emuName" "$(getReleaseURLGH "shadps4-emu/shadPS4" "zip" "linux-qt")" "$HOME/Applications/${ShadPS4_emuName}.zip" "$showProgress"; then
+        unzip -o "$HOME/Applications/${ShadPS4_emuName}.zip" -d "$ShadPS4_emuPath" && rm -f "$HOME/Applications/${ShadPS4_emuName}.zip"
+        if ! installEmuAI "$ShadPS4_emuName" "" "" "$ShadPS4_emuFileName" "" "emulator"; then # installEmuAI will handle everything when URL is not provided but AppImage exists...
+            echo "Error installing ShadPS4"
+            return 1
+        fi
+    else
+        echo "Error installing ShadPS4"
+        return 1
+    fi
 }
-
 
 ShadPS4_init(){
 	configEmuAI "$ShadPS4_emuName" "config" "$HOME/.local/share/shadPS4" "$EMUDECKGIT/configs/shadps4" "true"
@@ -63,7 +67,6 @@ ShadPS4_setupSaves(){
     linkToSaveFolder shadps4 saves "${ShadPS4_dir}/savedata"
     echo "ShadPS4 save link completed"
 }
-
 
 #SetupStorage
 ShadPS4_setupStorage(){

--- a/functions/EmuScripts/emuDeckShadPS4.sh
+++ b/functions/EmuScripts/emuDeckShadPS4.sh
@@ -33,12 +33,12 @@ ShadPS4_install(){
 }
 
 ShadPS4_init(){
-	configEmuAI "$ShadPS4_emuName" "config" "$HOME/.local/share/shadPS4" "$EMUDECKGIT/configs/shadps4" "true"
-	ShadPS4_setupStorage
-	ShadPS4_setEmulationFolder
-	ShadPS4_setupSaves
-	ShadPS4_flushEmulatorLauncher
-	ShadPS4_setLanguage
+    configEmuAI "$ShadPS4_emuName" "config" "$HOME/.local/share/shadPS4" "$EMUDECKGIT/configs/shadps4" "true"
+    ShadPS4_setupStorage
+    ShadPS4_setEmulationFolder
+    ShadPS4_setupSaves
+    ShadPS4_flushEmulatorLauncher
+    ShadPS4_setLanguage
 }
 
 ShadPS4_update(){
@@ -49,6 +49,12 @@ ShadPS4_update(){
 ShadPS4_setEmulationFolder(){
     echo "Begin ShadPS4 Path Config"
     sed -i "s|/run/media/mmcblk0p1/Emulation|${emulationPath}|g" "$ShadPS4_configFile"
+
+    # setup bios link for LLE sys_modules (optional)
+    mkdir -p "${biosPath}/shadps4/"
+    mkdir -p "ShadPS4_dir/sys_modules"
+    ln -sn "ShadPS4_dir/sys_modules" "${biosPath}/shadps4/sys_modules"
+
     echo "ShadPS4 Path Config Completed"
 }
 
@@ -125,9 +131,9 @@ ShadPS4_resetConfig(){
 }
 
 ShadPS4_setResolution(){
-	echo "NYI"
+    echo "NYI"
 }
 
 ShadPS4_flushEmulatorLauncher(){
-	flushEmulatorLaunchers "ShadPS4"
+    flushEmulatorLaunchers "ShadPS4"
 }

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -29,7 +29,7 @@ Xenia_install(){
 
 	#need to look at standardizing exe name; or download both?  let the user choose at runtime?
 	#curl -L "$Xenia_releaseURL" --output "$romsPath"/xbox360/xenia.zip
-	if safeDownload "$Xenia_emuName" "https://github.com/xenia-canary/xenia-canary/releases/download/eb99874/xenia_canary.zip" "$romsPath/xbox360/xenia.zip" "$showProgress"; then
+	if safeDownload "$Xenia_emuName" "$Xenia_releaseURL" "$romsPath/xbox360/xenia.zip" "$showProgress"; then
 		#mkdir -p "$romsPath"/xbox360/tmp
 		unzip -o "$romsPath"/xbox360/xenia.zip -d "$romsPath"/xbox360
 		#rsync -avzh "$romsPath"/xbox360/tmp/ "$romsPath"/xbox360/

--- a/functions/installEmuAI.sh
+++ b/functions/installEmuAI.sh
@@ -62,7 +62,7 @@ installEmuAI(){
         return 1
     fi
 
-    chmod +x "$HOME/Applications/$fileName.AppImage"
+    chmod +x "$HOME/Applications/$fileName.${format}"
     if [[ -n $lastVerFile ]] && [[ -n $latestVer ]]; then
         echo "latest version $latestVer > $lastVerFile"
         echo "$latestVer" > "$lastVerFile"

--- a/tools/emu-launch.sh
+++ b/tools/emu-launch.sh
@@ -2,9 +2,11 @@
 
 ## emu-launch.sh
 
+source "$HOME/.config/EmuDeck/backend/functions/all.sh"
+
 # Attempt to find the given program as an AppImage
 getAppImage () {
-    local EMUDIR="${HOME}/.config/EmuDeck/Emulators"
+    local EMUDIR="$emusFolder"
 
     # Check for AppImage
     local APPIMAGE

--- a/tools/generic-applications/Heroic-Games-Launcher.sh
+++ b/tools/generic-applications/Heroic-Games-Launcher.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-"$HOME/.config/EmuDeck/Emulators/Heroic-Games-Launcher.AppImage"
+source "$HOME/.config/EmuDeck/backend/functions/all.sh"
+
+"$emusFolder/Heroic-Games-Launcher.AppImage"

--- a/tools/launchers/shadps4.sh
+++ b/tools/launchers/shadps4.sh
@@ -31,10 +31,25 @@ fi
 fileExtension="${@##*.}"
 
 if [[ $fileExtension == "desktop" ]]; then
-    rpcs3desktopFile=$(grep -E "^Exec=" "${*}" | sed 's/^Exec=//' | sed 's/%%/%/g')
-    launchParam="Exec=$rpcs3desktopFile"
-    launchParam=$(echo "$launchParam" | sed "s|^\(Exec=\)[^\"']*\"|\1$emusFolder/Shadps4-qt.AppImage -g \"|" | sed 's/^Exec=//')
-    eval $launchParam
+    # trying to figure this out... :)
+    # In desktop file the Exec line is like this:
+    # Exec=/tmp/.mount_ShadpsT3Dso0/usr/bin/shadps4 "/run/media/mmcblk0p1/Emulation/storage/shadps4/games/CUSA01369/eboot.bin"
+
+    # takes desktop file and extracts Exec= line
+    shadps4DesktopExec=$(grep -E "^Exec=" "${*}" | sed 's/^Exec=//' | sed 's/%%/%/g')
+
+    # commented, doing it bit different...
+    #launchParam="Exec=$shadps4DesktopExec" # construct new Exec= line
+    #launchParam=$(echo "$launchParam" | sed "s|^\(Exec=\)[^\"']*\"|\1$emusFolder/Shadps4-qt.AppImage -g \"|" | sed 's/^Exec=//')
+
+    # this removes everything in Exec= line before first " or ' (quotes), keeps everything after that (including the quotes)
+    # given example above, result will be: "/run/media/mmcblk0p1/Emulation/storage/shadps4/games/CUSA01369/eboot.bin"
+    launchParam=$(echo "Exec=$shadps4DesktopExec" | sed "s|^\(Exec=\)[^\"\']*\([\"\']\)|\2|")
+    
+    # construct launch args and run
+    launch_args=("-g" "$launchParam")
+    echo "Launching: ${exe[*]} ${launch_args[*]}"
+    "${exe[@]}" "${launch_args[@]}"
 else
     #run the executable with the params.
     launch_args=()

--- a/tools/launchers/shadps4.sh
+++ b/tools/launchers/shadps4.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 source $HOME/.config/EmuDeck/backend/functions/all.sh
 emulatorInit "shadps4"
-emuName="Shadps4-qt" #parameterize me
-emufolder="$HOME/Applications" # has to be applications for ES-DE to find it
 
 #initialize execute array
 exe=()
 
 #find full path to emu executable
-exe_path=$(find "$emufolder" -iname "${emuName}*.AppImage" | sort -n | cut -d' ' -f 2- | tail -n 1 2>/dev/null)
+exe_path=$(find "$ShadPS4_emuPath" -iname "${ShadPS4_emuFileName}*.AppImage" | sort -n | cut -d' ' -f 2- | tail -n 1 2>/dev/null)
 
 #if appimage doesn't exist fall back to flatpak.
 if [[ -z "$exe_path" ]]; then
     #flatpak
-    flatpakApp=$(flatpak list --app --columns=application | grep "$RPCS3_emuPathFlatpak")
+    flatpakApp=$(flatpak list --app --columns=application | grep "$ShadPS4_emuName")
+    #check if flatpakApp is empty
+    if [[ -z "$flatpakApp" ]]; then
+        echo "Flatpak for '$ShadPS4_emuName' not found."
+        exit 1
+    fi
     #fill execute array
     exe=("flatpak" "run" "$flatpakApp")
 else
@@ -26,10 +29,25 @@ fi
 fileExtension="${@##*.}"
 
 if [[ $fileExtension == "desktop" ]]; then
-    rpcs3desktopFile=$(grep -E "^Exec=" "${*}" | sed 's/^Exec=//' | sed 's/%%/%/g')
-    launchParam="Exec=$rpcs3desktopFile"
-    launchParam=$(echo "$launchParam" | sed "s|^\(Exec=\)[^\"']*\"|\1$HOME/Applications/Shadps4-qt.AppImage -g \"|" | sed 's/^Exec=//')
-    eval $launchParam
+    # trying to figure this out... :)
+    # In desktop file the Exec line is like this:
+    # Exec=/tmp/.mount_ShadpsT3Dso0/usr/bin/shadps4 "/run/media/mmcblk0p1/Emulation/storage/shadps4/games/CUSA01369/eboot.bin"
+
+    # takes desktop file and extracts Exec= line
+    shadps4DesktopExec=$(grep -E "^Exec=" "${*}" | sed 's/^Exec=//' | sed 's/%%/%/g')
+
+    # commented, doing it bit different...
+    #launchParam="Exec=$shadps4DesktopExec" # construct new Exec= line
+    #launchParam=$(echo "$launchParam" | sed "s|^\(Exec=\)[^\"']*\"|\1$HOME/Applications/Shadps4-qt.AppImage -g \"|" | sed 's/^Exec=//')
+
+    # this removes everything in Exec= line before first " or ' (quotes), keeps everything after that (including the quotes)
+    # given example above, result will be: "/run/media/mmcblk0p1/Emulation/storage/shadps4/games/CUSA01369/eboot.bin"
+    launchParam=$(echo "Exec=$shadps4DesktopExec" | sed "s|^\(Exec=\)[^\"\']*\([\"\']\)|\2|")
+    
+    # construct launch args and run
+    launch_args=("-g" "$launchParam")
+    echo "Launching: ${exe[*]} ${launch_args[*]}"
+    "${exe[@]}" "${launch_args[@]}"
 else
     #run the executable with the params.
     launch_args=()
@@ -42,7 +60,7 @@ else
     echo "Launching: ${exe[*]} ${launch_args[*]}"
 
     if [[ -z "${*}" ]]; then
-        echo "ROM not found. Launching $emuName directly"
+        echo "ROM not found. Launching $ShadPS4_emuName directly"
         "${exe[@]}"
     else
         echo "ROM found, launching game"

--- a/tools/launchers/yuzu.sh
+++ b/tools/launchers/yuzu.sh
@@ -25,7 +25,7 @@ if [[ ! $emuExeFile =~ "AppImage" ]]; then
 	emuExeFile=$(find "$emufolder" -iname "${emuName}*.AppImage" | sort -n | cut -d' ' -f 2- | tail -n 1 2>/dev/null)
 fi
 if [[ ! $emuExeFile =~ "AppImage" ]]; then
-	 zenity --info --title="Yuzu AppImage not found!" --width 200 --text "Please check that you have the appimage in ~/.config/EmuDeck/Emulators or \nrerun Emudeck and ensure it is installed." 2>/dev/null
+	 zenity --info --title="Yuzu AppImage not found!" --width 200 --text "Please check that you have the AppImage in ${emusFolder} or \nrerun Emudeck and ensure it is installed." 2>/dev/null
 fi
 isMainline=true
 if [ ! "$emuExeFile" = "$emufolder/$emuName.AppImage" ]; then

--- a/tools/remoteplayclients/Greenlight.sh
+++ b/tools/remoteplayclients/Greenlight.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-"$HOME/.config/EmuDeck/Emulators/Greenlight.AppImage"
+source "$HOME/.config/EmuDeck/backend/functions/all.sh"
+
+"$emusFolder/Greenlight.AppImage"

--- a/tools/remoteplayclients/ShadowPC.sh
+++ b/tools/remoteplayclients/ShadowPC.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-"$HOME/.config/EmuDeck/Emulators/ShadowPC.AppImage"
+source "$HOME/.config/EmuDeck/backend/functions/all.sh"
+
+"$emusFolder/ShadowPC.AppImage"

--- a/tools/remoteplayclients/chiaki-ng.sh
+++ b/tools/remoteplayclients/chiaki-ng.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-"$HOME/.config/EmuDeck/Emulators/chiaki-ng.AppImage"
+source "$HOME/.config/EmuDeck/backend/functions/all.sh"
+
+"$emusFolder/chiaki-ng.AppImage"

--- a/tools/savesync.sh
+++ b/tools/savesync.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
+source "$HOME/.config/EmuDeck/backend/functions/all.sh"
 SAVESYNC_toolName="EmuDeck SaveSync"
 SAVESYNC_toolType="AppImage"
-SAVESYNC_toolPath="$HOME/.config/EmuDeck/Emulators/EmuDeck_SaveSync.AppImage"
+SAVESYNC_toolPath="$emusFolder/EmuDeck_SaveSync.AppImage"
 SAVESYNC_systemd_path="$HOME/.config/systemd/user"
-
-source "$HOME/.config/EmuDeck/backend/functions/all.sh"
 
 SAVESYNC_install(){	
 	


### PR DESCRIPTION
ShadPS4
- separate download/unzip/AppImage setup when installing; download zip first, then unzip and then do AppImage things (installEmuAI)
- create bios link for LLE sys_modules (optional)
- launcher: we can use variables from emu script
- launcher: fallback to flatpak handled more gracefully
- launcher: better handling of .desktop file arguments

Ryujinx
- currently, the "nogui" version is downloaded; it doesn't make a difference but it might later; implement fileNameDoesNotContain in getReleaseURLGH helper function and make use of it for Ryu

Xenia
- latest version is running fine, removed hardcoded release