### PR TITLE
Cemu: Disable input for blow mic hotkey

### DIFF
--- a/configs/cemu/config/cemu/settings.xml
+++ b/configs/cemu/config/cemu/settings.xml
@@ -95,7 +95,7 @@
         <InputVolume>100</InputVolume>
         <TVDevice>default</TVDevice>
         <PadDevice>default</PadDevice>
-        <InputDevice>default</InputDevice>
+        <InputDevice></InputDevice>
     </Audio>
     <Account>
         <PersistentId>2147483649</PersistentId>


### PR DESCRIPTION
# PR Description
Fixed a bug in Cemu that brakes the blow mic button, input device is experimental so it doesn't function on any device I tested (Steamdeck and Windows)
Setting this line to empty disables the input and blow mic functions normally

## Usage:
EmuDeck is a free open source project, but we have an Early Access tier on Patreon where people can get timely exclusive to some features.

Do you allow us to merge this PR to the Early Access branch, or do you only want your work to be available when the next public build is released?

- [x] Early Access, Public Beta and Public
- [ ] Public and Beta only

## Checklist:
- [x] I am using the dev branch as the target for this PR.
- [-] I've tested and verified that the PR works in at least one device.
- [x] I've checked that my PR doesn't do anything wild like deleting user saved games :)
- [x] If I'm using a third party binary or tool from other developer I'm allowed to use it.

I've tested the setting manually and copied to another installation to test and it works, I assume emudeck copies only the file so it should work