### PR TITLE
Add ZSO to the file formats supported in SRM for PCSX2

### DIFF
--- a/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps2-pcsx2.json
+++ b/configs/steam-rom-manager/userData/parsers/emudeck/sony_ps2-pcsx2.json
@@ -21,7 +21,7 @@
     "appendArgsToExecutable": false
   },
   "parserInputs": {
-    "glob": "**/${title}@(.bin|.BIN|.chd|.CHD|.cso|.CSO|.dump|.DUMP|.gz|.GZ|.img|.IMG|.iso|.ISO|.mdf|.MDF|.nrg|.NRG)"
+    "glob": "**/${title}@(.bin|.BIN|.chd|.CHD|.cso|.CSO|.dump|.DUMP|.gz|.GZ|.img|.IMG|.iso|.ISO|.mdf|.MDF|.nrg|.NRG|.zso|.ZSO)"
   },
   "titleFromVariable": {
     "limitToGroups": "",


### PR DESCRIPTION
For a bit more than a year PCSX2 has supported ZSO roms, can we add this so it's automatically handled and I don't have to create a new line in the parser every time?

https://github.com/PCSX2/pcsx2/commit/00e255ee3c713dfa5c85e714dc9120a5d2aa039e

Thank you! 