### PR TITLE
Add ES-DE find rule for Dolphin on ChimeraOS

### DIFF
--- a/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/chimeraOS/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -8,6 +8,11 @@
             <entry>sh</entry>
         </rule>
     </emulator>
+    <emulator name="DOLPHIN">
+        <rule type="staticpath">
+            <entry>~/.local/share/flatpak/exports/bin/org.DolphinEmu.dolphin-emu</entry>
+        </rule>
+    </emulator>
     <emulator name="RETROARCH">
         <rule type="systempath">
             <entry>org.libretro.RetroArch</entry>


### PR DESCRIPTION
This adds an ES-DE find rule so that the version of Dolphin installed by EmuDeck is launched on ChimeraOS.  This fixes an issue where the version of Dolphin provided by ChimeraOS can be launched instead, resulting in the EmuDeck configs and settings not being used.

Fixes #1405
