### PR TITLE
Fix_Cemu_SRM_userConfigurations.json

### DIFF
--- a/configs/steam-rom-manager/userData/userConfigurations.json
+++ b/configs/steam-rom-manager/userData/userConfigurations.json
@@ -4056,7 +4056,7 @@
         },
         "defaultImage": {
             "tall": "",
-            "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",
+            "long": "",
             "hero": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/hero.png",
             "logo": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/logo.png",
             "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"
@@ -4183,7 +4183,7 @@
         },
         "defaultImage": {
             "tall": "",
-            "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",
+            "long": "",
             "hero": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/hero.png",
             "logo": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/logo.png",
             "icon": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/default/icon.png"


### PR DESCRIPTION
Fix Cemu invalid in SRM : userConfigurations.json
fix the line 4059 and 4186 :
            "long": "/home/deck/.config/EmuDeck/backend/configs/steam-rom-manager/userData/img/systems/grid/wiiu.jpg",

-> dosnt exist anymore . 
Generates invalid emulator in SRM .