### PR TITLE
Fix_shadps4.sh_ES-DE_shortcut

### DIFF
--- a/tools/launchers/shadps4.sh
+++ b/tools/launchers/shadps4.sh
@@ -44,8 +44,13 @@ if [[ $fileExtension == "desktop" ]]; then
 
     # this removes everything in Exec= line before first " or ' (quotes), keeps everything after that (including the quotes)
     # given example above, result will be: "/run/media/mmcblk0p1/Emulation/storage/shadps4/games/CUSA01369/eboot.bin"
-    launchParam=$(echo "Exec=$shadps4DesktopExec" | sed "s|^\(Exec=\)[^\"\']*\([\"\']\)|\2|")
-    
+    launchParam=$(echo "$shadps4DesktopExec" | grep -oP '"\K[^"]+(?=")')
+
+    # fallback : si pas trouvé avec guillemets, prend dernier mot
+    if [[ -z "$launchParam" ]]; then
+        launchParam=$(echo "$shadps4DesktopExec" | awk '{print $NF}')
+    fi
+
     # construct launch args and run
     launch_args=("-g" "$launchParam")
     echo "Launching: ${exe[*]} ${launch_args[*]}"


### PR DESCRIPTION
Make shadps4.sh launch shortcut.dekstop in ES-DE . 
Seems is just an issue with parsing the exec line of the game. 

change the way of grabbing to get the eboot.bin under quotes. 
and fallback : 
If no quotes = takes last word.

