### PR TITLE
Fix Azahar -  ESDE Radial menu and backbuttons

### DIFF
--- a/configs/steam-input/emudeck_controller_steamdeck_radial_menus.vdf
+++ b/configs/steam-input/emudeck_controller_steamdeck_radial_menus.vdf
@@ -1090,7 +1090,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press X, Stop Emulation, EmuDeck_Quit-Exit.png, #232323 #AD0000"
+							"binding"		"key_press LEFT_ALT, Stop Emulation, EmuDeck_Quit-Exit.png, #232323 #AD0000"
+							"binding"		"key_press F4, Stop Emulation, EmuDeck_Quit-Exit.png, #232323 #AD0000"
 						}
 						"settings"
 						{
@@ -20889,7 +20890,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press E, Layout Toggle, , "
+							"binding"		"key_press TAB, Layout Toggle, , "
 						}
 					}
 				}
@@ -20905,7 +20906,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press X, Hold to Quit, , "
+							"binding"		"key_press LEFT_ALT, Hold to Quit, , "
+							"binding"		"key_press F4, Hold to Quit, , "
 						}
 						"settings"
 						{
@@ -20925,7 +20927,7 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press F, Toggle Full Screen, , "
+							"binding"		"key_press F11, Toggle Full Screen, , "
 						}
 					}
 				}
@@ -20941,7 +20943,8 @@
 					{
 						"bindings"
 						{
-							"binding"		"key_press S, Swap Screens, , "
+							"binding"		"key_press LEFT_CONTROL, Swap Screens, , "
+							"binding"		"key_press TAB, Swap Screens, , "
 						}
 					}
 				}


### PR DESCRIPTION
following my search in the issue https://github.com/dragoonDorise/EmuDeck/issues/1451

some keys / button seems to no be mapped according to the ini provided : 

adial Menu Citra :
Special touch_menu_button_7 X:key to Exit Not working
Also
Missing back buttons
F key toggle full screen = L4 --- ini Shortcuts\Main%20Window\Fullscreen\KeySeq=F11
E key layout toggle = L5 -------- ini Shortcuts\Main%20Window\Toggle%20Screen%20Layout\KeySeq=Tab
S key Swap screen = R4 ---------- ini Shortcuts\Main%20Window\Swap%20Screens\KeySeq=Ctrl+Tab
X key Quit = R5 ----------------- ini Shortcuts\Main%20Window\Exit%20Citra\KeySeq=Alt+F4

So i applied right mapping in steam and exported the lines changed to add it in the main repo.
Then i downloaded the modified VDF and tested it with Azahar appimage throught ES-DE latest installed with emudeck . 
L4 L5 R4 R5 are now mapped corredtly 
and button menu 7 quits. 
 
I dont know if there is other stuff to change . i cannot remember if start + select was included with radial ? 