### PR TITLE
fix retroarch cores es_find_rules.xml

### DIFF
--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -15,7 +15,7 @@
     </emulator>
     <core name="RETROARCH">
         <rule type="corepath">
-            <entry>~/.config/retroarch/cores</entry>
+            <entry>~/.var/app/org.libretro.RetroArch/config/cores</entry>
         </rule>
     </core>
     <emulator name="SHADPS4">


### PR DESCRIPTION
Ive noted an issue using this  find rules file . 

the cores path given point to non-existent directory for the cores: 
```
    <core name="RETROARCH">
        <rule type="corepath">
            <entry>~/.config/retroarch/cores</entry>
```
https://github.com/dragoonDorise/EmuDeck/blob/main/configs/emulationstation/custom_systems/es_find_rules.xml

But according to the emucsript of retroarch : 
`RetroArch_cores="$HOME/.var/app/org.libretro.RetroArch/config/retroarch/cores"`
https://github.com/dragoonDorise/EmuDeck/blob/main/functions/EmuScripts/emuDeckRetroArch.sh

For example here is a result using old ~/.config/retroarch/cores: for all system using cores having error not found : 

```
Apr 20 12:45:19 Info:   Launching game "2020 Super Baseball" from system "SNK Neo Geo (neogeo)"...
Apr 20 12:45:19 Error:  Couldn't launch game, emulator core file "fbneo_libretro.so" not found
Apr 20 12:45:19 Error:  Raw emulator launch command:
Apr 20 12:45:19 Error:  %EMULATOR_RETROARCH% -L %CORE_RETROARCH%/fbneo_libretro.so %ROM%
Apr 20 12:45:19 Error:  Tried to find the core file using these paths as defined by es_find_rules.xml:
Apr 20 12:45:19 Error:  ~/.config/retroarch/cores
Apr 20 12:45:34 Info:   ES-DE cleanly shutting down
```
replacing the line with : ~/.var/app/org.libretro.RetroArch/config/retroarch/cores fix the issue . 

I cannot really tell if its general issue or just on my side but it doesnt make sense reading the emuDeckRetroArch.sh to point to ~/.config/retroarch/cores
