### PR TITLE
Cloud Services Manager: Add an alternative Twitch version

### DIFF
--- a/tools/cloud/Twitch (TV Mode).sh
+++ b/tools/cloud/Twitch (TV Mode).sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+. "$HOME/.config/EmuDeck/backend/functions/all.sh"
+source "$romsPath/cloud/cloud.conf"
+
+LINK="https://localhost.tv.twitch.tv/"
+
+browsercommand


### PR DESCRIPTION
Add an alternative version for Twitch.
This seems to be the url the Twitch Android TV application is using.

It has a UI that is better suited for a TV, adding an easier way to log in and navigation without mouse becomes simpler.
From what I can tell it does not natively support a gamepad. Mapping the dpad to the arrow keys works like a charm though.