### PR TITLE
chore: Fix broken image url for game

### DIFF
--- a/store/gbc/Himes Quest.json
+++ b/store/gbc/Himes Quest.json
@@ -8,10 +8,10 @@
   "description": "It’s 1999, and something electric is in the air. A malevolent force has crept into New Crunchy City, wreaking havoc on its technology and tragically destroying the Anime Club’s DVD / VCR combo player. Enter Hime to save the day!",
   "pictures": {
     "screenshots": [
-      "https://raw.githubusercontent.com/EmuDeck/emudeck-homebrew/main/downloaded_media/gbc/screenshots/homebrew/himes-quest.png?raw=true"
+      "https://raw.githubusercontent.com/EmuDeck/emudeck-homebrew/main/downloaded_media/gbc/screenshots/homebrew/Himes%20Quest.png?raw=true"
     ],
     "titlescreens": [
-      "https://raw.githubusercontent.com/EmuDeck/emudeck-homebrew/main/downloaded_media/gbc/titlescreens/homebrew/himes-quest.png?raw=true"
+      "https://raw.githubusercontent.com/EmuDeck/emudeck-homebrew/main/downloaded_media/gbc/titlescreens/homebrew/Himes%20Quest.png?raw=true"
     ]
   },
   "tags": ["rpg"]


### PR DESCRIPTION
This image is broken url causing interface to be blank. This PR fixes the image url to match the existing image file.