### PR TITLE
Fixed debian deps command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@ sandbox=""
 
 if [ "$linuxID" = "Ubuntu" ]; then
     UBUNTU_VERSION=$(lsb_release -rs)
-    if [[ "$UBUNTU_VERSION" == "24.04" ]] || [[ "$UBUNTU_VERSION" > "24.04" ]]; then
+    # Compara usando dpkg para versiones >= 24.04
+    if dpkg --compare-versions "$UBUNTU_VERSION" ge "24.04"; then
         # Instala curl si falta (necesario en Ubuntu 24.04+)
         if ! command -v curl &> /dev/null; then
             echo "curl not found, installing curl first..."
@@ -24,6 +25,7 @@ if [ "$linuxID" = "Ubuntu" ]; then
     fi
     sandbox="--no-sandbox"
 fi
+
 clear
 
 if [ "$linuxID" == "SteamOS" ]; then

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,17 @@ linuxID=$(lsb_release -si)
 sandbox=""
 
 if [ "$linuxID" = "Ubuntu" ]; then
+    UBUNTU_VERSION=$(lsb_release -rs)
+    if [[ "$UBUNTU_VERSION" == "24.04" ]] || [[ "$UBUNTU_VERSION" > "24.04" ]]; then
+        # Instala curl si falta (necesario en Ubuntu 24.04+)
+        if ! command -v curl &> /dev/null; then
+            echo "curl not found, installing curl first..."
+            sudo apt-get update
+            sudo apt-get install -y curl
+        fi
+        # Cambia dependencias para Ubuntu 24.04+
+        DEBIAN_DEPS=(jq zenity flatpak unzip bash libfuse2t64 git rsync whiptail python3 curl)
+    fi
     sandbox="--no-sandbox"
 fi
 clear


### PR DESCRIPTION
The debian_deps command has been fixed to work with Ubuntu 24.04 or higher.