### PR TITLE
Update url emuDeckXenia.sh

### DIFF
--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -6,7 +6,7 @@ Xenia_emuPath="${romsPath}/xbox360/xenia_canary.exe"
 Xenia_releaseURL_master="https://github.com/xenia-project/release-builds-windows/releases/latest/download/xenia_master.zip"
 #Xenia_releaseURL_canary="https://github.com/xenia-canary/xenia-canary/releases/latest/download/xenia_canary.zip"
 # TODO - https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_linux.tar.gz - Linux build, runs on SteamDeck =)
-Xenia_releaseURL_canary="https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_windows.zip"
+Xenia_releaseURL_canary="https://github.com/xenia-canary/xenia-canary-releases/releases/download/canary_experimental/xenia_canary_windows.zip"
 Xenia_XeniaSettings="${romsPath}/xbox360/xenia-canary.config.toml"
 
 #cleanupOlderThings


### PR DESCRIPTION
User reported a error on install url of xenia script : 


```
homeИ — 09:29
Can we somehow change URL for Xenia installation?
From this: https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_windows.zip
To this: https://github.com/xenia-canary/xenia-canary-releases/releases/download/canary_experimental/xenia_canary_windows.zip

Right now an installation script is not working correctly. The link is taken from the official Xenia Discord group. 
```

Indeed the old URL is not found : 
<img width="1255" height="186" alt="image" src="https://github.com/user-attachments/assets/b311019f-c99e-4055-a86e-175e5844d9a4" />

