### PR TITLE
[cloud-tool] Update YouTube.sh to support launching in TV UI

### DIFF
--- a/tools/cloud/YouTube.sh
+++ b/tools/cloud/YouTube.sh
@@ -4,4 +4,16 @@ source "$romsPath/cloud/cloud.conf"
 
 LINK="https://www.youtube.com/"
 
+# Allow opening YouTube TV with a --tv flag
+# You will need to make sure your browser is set up to open YouTube in TV UI.
+# This can be done in browsers like Firefox by setting a custom user agent or
+# installing 3P browser extensions.
+for arg in "$@"; do
+	case "$arg" in
+		--tv)
+			LINK="https://www.youtube.com/tv/"
+			;;
+	esac
+done
+
 browsercommand


### PR DESCRIPTION
Add a `--tv` flag to YouTube.sh to open www.youtube.com/tv/ instead. Users can pass this flag through Steam's Game UI's launch option.

Users will need to set up their browser to support opening YouTube in TV UI. E.g. installing the [YouTube Smart TV](https://addons.mozilla.org/en-US/firefox/addon/youtube-for-tv/) extension.