### PR TITLE
Fix for path in azahar launcher

### DIFF
--- a/tools/launchers/azahar.sh
+++ b/tools/launchers/azahar.sh
@@ -2,7 +2,7 @@
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 emulatorInit "azahar"
 emuName="azahar" #parameterize me
-emufolder="$emusFolder" # has to be applications for ES-DE to find it
+emufolder="$emusFolder/" # has to be applications for ES-DE to find it
 
 #initialize execute array
 exe=()


### PR DESCRIPTION
The launcher expects that emufolder has an trailing slash when calculating the exe_path. vars.sh does not have this slash so the path is not set correctly.

It is weird that there has never been an issue about this. So it might be an problem with my specific install. I did check and I am on the latest commit.