### PR TITLE
More portable launchers

### DIFF
--- a/functions/EmuScripts/emuDeckAzahar.sh
+++ b/functions/EmuScripts/emuDeckAzahar.sh
@@ -332,7 +332,7 @@ Azahar_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Nintendo 3DS' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/n3ds' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.3ds .3DS .3dsx .3DSX .app .APP .axf .AXF .cci .CCI .cxi .CXI .elf .ELF .7z .7Z .zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/azahar.sh %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/azahar.sh %ROM%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "Azahar (Standalone)" \
 		--subnode '$newSystem' --type elem --name 'platform' -v 'n3ds' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'n3ds' \

--- a/functions/EmuScripts/emuDeckBigPEmu.sh
+++ b/functions/EmuScripts/emuDeckBigPEmu.sh
@@ -98,7 +98,7 @@ BigPEmu_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Atari Jaguar' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/atarijaguar' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.abs .ABS .bin .BIN .cdi .CDI .cof .COF .cue .CUE .j64 .J64 .jag .JAG .prg .PRG .rom .ROM .7z .7Z .zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandB' -v "/usr/bin/bash ${toolsPath}/launchers/bigpemu.sh %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandB' -v "/usr/bin/env bash ${toolsPath}/launchers/bigpemu.sh %ROM%" \
 		--insert '$newSystem/commandB' --type attr --name 'label' --value "BigPEmu" \
 		--subnode '$newSystem' --type elem --name 'commandV' -v "%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/virtualjaguar_libretro.so %ROM%" \
 		--insert '$newSystem/commandV' --type attr --name 'label' --value "Virtual Jaguar" \
@@ -123,7 +123,7 @@ BigPEmu_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Atari Jaguar CD' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/atarijaguarcd' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.abs .ABS .bin .BIN .cdi .CDI .cof .COF .cue .CUE .j64 .J64 .jag .JAG .prg .PRG .rom .ROM .7z .7Z .zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandB' -v "/usr/bin/bash ${toolsPath}/launchers/bigpemu.sh %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandB' -v "/usr/bin/env bash ${toolsPath}/launchers/bigpemu.sh %ROM%" \
 		--insert '$newSystem/commandB' --type attr --name 'label' --value "BigPEmu" \
 		--subnode '$newSystem' --type elem --name 'platform' -v 'atarijaguarcd' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'atarijaguarcd' \

--- a/functions/EmuScripts/emuDeckCemuProton.sh
+++ b/functions/EmuScripts/emuDeckCemuProton.sh
@@ -158,9 +158,9 @@ CemuProton_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Nintendo Wii U' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/wiiu/roms' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.elf .ELF .rpx .RPX .tmd .TMD .wua .WUA .wud .WUD .wuhb .WUHB .wux .WUX' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/cemu.sh -f -g z:%ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/cemu.sh -f -g z:%ROM%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "Cemu (Native)" \
-		--subnode '$newSystem' --type elem --name 'commandN' -v "/bin/bash ${toolsPath}/launchers/cemu.sh -w -f -g %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandN' -v "/usr/bin/env bash ${toolsPath}/launchers/cemu.sh -w -f -g %ROM%" \
 		--insert '$newSystem/commandN' --type attr --name 'label' --value "Cemu (Proton)" \
 		--subnode '$newSystem' --type elem --name 'platform' -v 'wiiu' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'wiiu' \

--- a/functions/EmuScripts/emuDeckModel2.sh
+++ b/functions/EmuScripts/emuDeckModel2.sh
@@ -71,7 +71,7 @@ Model2_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Sega Model 2' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/model2/roms' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "Model 2 Emulator (Proton)" \
 		--subnode '$newSystem' --type elem --name 'platform' -v 'arcade' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'model2' \

--- a/functions/EmuScripts/emuDeckXenia.sh
+++ b/functions/EmuScripts/emuDeckXenia.sh
@@ -94,7 +94,7 @@ Xenia_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Microsoft Xbox 360' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/xbox360/roms' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.iso .ISO . .xex .XEX' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/xenia.sh z:%ROM% %INJECT%=%BASENAME%.esprefix" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/xenia.sh z:%ROM% %INJECT%=%BASENAME%.esprefix" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "Xenia (Proton)" \
 		--subnode '$newSystem' --type elem --name 'platform' -v 'xbox360' \
 		--subnode '$newSystem' --type elem --name 'theme' -v 'xbox360' \

--- a/functions/EmuScripts/emuDeckares.sh
+++ b/functions/EmuScripts/emuDeckares.sh
@@ -99,7 +99,7 @@ ares_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Bandai SuFami Turbo' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/sufami' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.bml .BML .bs .BS .fig .FIG .sfc .SFC .smc .SMC .st .ST .7z .7Z .zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/ares-emu.sh STBIOS.bin --fullscreen --system \"Super Famicom\" %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/ares-emu.sh STBIOS.bin --fullscreen --system \"Super Famicom\" %ROM%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "ares (Standalone)" \
 		--subnode '$newSystem' --type elem --name 'commandQ' -v "%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/snes9x_libretro.so %ROM%" \
 		--insert '$newSystem/commandQ' --type attr --name 'label' --value "Snes9x - Current" \
@@ -140,7 +140,7 @@ ares_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Nintendo Satellaview' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/satellaview' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.bml .BML .bs .BS .fig .FIG .sfc .SFC .smc .SMC .swc .SWC .st .ST .7z .7Z .zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/ares-emu.sh BS-X.bin --fullscreen --system \"Super Famicom\" %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/ares-emu.sh BS-X.bin --fullscreen --system \"Super Famicom\" %ROM%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "ares (Standalone)" \
 		--subnode '$newSystem' --type elem --name 'commandQ' -v "%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/snes9x_libretro.so %ROM%" \
 		--insert '$newSystem/commandQ' --type attr --name 'label' --value "Snes9x - Current" \
@@ -181,7 +181,7 @@ ares_addESConfig(){
 		--subnode '$newSystem' --type elem --name 'fullname' -v 'Nintendo Super Game Boy' \
 		--subnode '$newSystem' --type elem --name 'path' -v '%ROMPATH%/sgb' \
 		--subnode '$newSystem' --type elem --name 'extension' -v '.gb .GB .gbc .GBC .sgb .SGB .7z .7Z .zip .ZIP' \
-		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/bash ${toolsPath}/launchers/ares-emu.sh SGB1.sfc --fullscreen --system \"Super Famicom\" %ROM%" \
+		--subnode '$newSystem' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/ares-emu.sh SGB1.sfc --fullscreen --system \"Super Famicom\" %ROM%" \
 		--insert '$newSystem/commandP' --type attr --name 'label' --value "ares (Standalone)" \
 		--subnode '$newSystem' --type elem --name 'commandQ' -v "%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mesen-s_libretro.so %ROM%" \
 		--insert '$newSystem/commandQ' --type attr --name 'label' --value "Mesen-S" \

--- a/functions/ToolScripts/emuDeckESDE.sh
+++ b/functions/ToolScripts/emuDeckESDE.sh
@@ -264,7 +264,7 @@ ESDE_setEmulationFolder(){
 	if [[ ! $(grep -rnw "$es_systemsFile" -e 'wiiu') == "" ]]; then
 		if [[ $(grep -rnw "$es_systemsFile" -e 'Cemu (Native)') == "" ]]; then
 			#insert
-			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="wiiu"]' --type elem --name 'commandN' -v "/bin/bash ${toolsPath}/launchers/cemu.sh -f -g %ROM%" \
+			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="wiiu"]' --type elem --name 'commandN' -v "/usr/bin/env bash ${toolsPath}/launchers/cemu.sh -f -g %ROM%" \
 			--insert 'systemList/system/commandN' --type attr --name 'label' --value "Cemu (Native)" \
 			-r 'systemList/system/commandN' -v 'command' \
 			"$es_systemsFile"
@@ -273,12 +273,12 @@ ESDE_setEmulationFolder(){
 			xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 		else
 			#update
-			cemuNativeCommandString="/bin/bash ${toolsPath}/launchers/cemu.sh -f -g %ROM%"
+			cemuNativeCommandString="/usr/bin/env bash ${toolsPath}/launchers/cemu.sh -f -g %ROM%"
 			xmlstarlet ed -L -u '/systemList/system/command[@label="Cemu (Native)"]' -v "$cemuNativeCommandString" "$es_systemsFile"
 		fi
 		if [[ $(grep -rnw "$es_systemsFile" -e 'Cemu (Proton)') == "" ]]; then
 			#insert
-			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="wiiu"]' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/cemu.sh -w -f -g z:%ROM%" \
+			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="wiiu"]' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/cemu.sh -w -f -g z:%ROM%" \
 			--insert 'systemList/system/commandP' --type attr --name 'label' --value "Cemu (Proton)" \
 			-r 'systemList/system/commandP' -v 'command' \
 			"$es_systemsFile"
@@ -287,14 +287,14 @@ ESDE_setEmulationFolder(){
 			xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 		else
 			#update
-			cemuProtonCommandString="/bin/bash ${toolsPath}/launchers/cemu.sh -w -f -g z:%ROM%"
+			cemuProtonCommandString="/usr/bin/env bash ${toolsPath}/launchers/cemu.sh -w -f -g z:%ROM%"
 			xmlstarlet ed -L -u '/systemList/system/command[@label="Cemu (Proton)"]' -v "$cemuProtonCommandString" "$es_systemsFile"
 		fi
 	fi
 	if [[ ! $(grep -rnw "$es_systemsFile" -e 'model2') == "" ]]; then
 		if [[ $(grep -rnw "$es_systemsFile" -e 'Model 2 Emulator (Proton)') == "" ]]; then
 			#insert
-			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="model2"]' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%" \
+			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="model2"]' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%" \
 			--insert 'systemList/system/commandP' --type attr --name 'label' --value "Model 2 Emulator (Proton)" \
 			-r 'systemList/system/commandP' -v 'command' \
 			"$es_systemsFile"
@@ -303,14 +303,14 @@ ESDE_setEmulationFolder(){
 			xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 		else
 			#update
-			model2ProtonCommandString="/bin/bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%"
+			model2ProtonCommandString="/usr/bin/env bash ${toolsPath}/launchers/model-2-emulator.sh %BASENAME%"
 			xmlstarlet ed -L -u '/systemList/system/command[@label="Model 2 Emulator (Proton)"]' -v "$model2ProtonCommandString" "$es_systemsFile"
 		fi
 	fi
 	if [[ ! $(grep -rnw "$es_systemsFile" -e 'atarijaguar') == "" ]]; then
 		if [[ $(grep -rnw "$es_systemsFile" -e 'BigPEmu (Proton)') == "" ]]; then
 			#insert
-			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="atarijaguar"]' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/bigpemu.sh %BASENAME%" \
+			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="atarijaguar"]' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/bigpemu.sh %BASENAME%" \
 			--insert 'systemList/system/commandP' --type attr --name 'label' --value "BigPEmu (Proton)" \
 			-r 'systemList/system/commandP' -v 'command' \
 			"$es_systemsFile"
@@ -319,14 +319,14 @@ ESDE_setEmulationFolder(){
 			xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 		else
 			#update
-			bigpemujaguarProtonCommandString="/bin/bash ${toolsPath}/launchers/bigpemu.sh %ROM%"
+			bigpemujaguarProtonCommandString="/usr/bin/env bash ${toolsPath}/launchers/bigpemu.sh %ROM%"
 			xmlstarlet ed -L -u '/systemList/system/command[@label="BigPEmu (Proton)"]' -v "$bigpemujaguarProtonCommandString" "$es_systemsFile"
 		fi
 	fi
 	if [[ ! $(grep -rnw "$es_systemsFile" -e 'atarijaguarcd') == "" ]]; then
 		if [[ $(grep -rnw "$es_systemsFile" -e 'BigPEmu (Proton)') == "" ]]; then
 			#insert
-			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="atarijaguarcd"]' --type elem --name 'commandP' -v "/bin/bash ${toolsPath}/launchers/bigpemu.sh %ROM%" \
+			xmlstarlet ed -S --inplace --subnode 'systemList/system[name="atarijaguarcd"]' --type elem --name 'commandP' -v "/usr/bin/env bash ${toolsPath}/launchers/bigpemu.sh %ROM%" \
 			--insert 'systemList/system/commandP' --type attr --name 'label' --value "BigPEmu (Proton)" \
 			-r 'systemList/system/commandP' -v 'command' \
 			"$es_systemsFile"
@@ -335,7 +335,7 @@ ESDE_setEmulationFolder(){
 			xmlstarlet fo "$es_systemsFile" > "$es_systemsFile".tmp && mv "$es_systemsFile".tmp "$es_systemsFile"
 		else
 			#update
-			bigpemujaguarcdProtonCommandString="/bin/bash ${toolsPath}/launchers/bigpemu.sh %ROM%"
+			bigpemujaguarcdProtonCommandString="/usr/bin/env bash ${toolsPath}/launchers/bigpemu.sh %ROM%"
 			xmlstarlet ed -L -u '/systemList/system/command[@label="BigPEmu (Proton)"]' -v "$bigpemujaguarcdProtonCommandString" "$es_systemsFile"
 		fi
 	fi

--- a/tools/emu-launch.sh
+++ b/tools/emu-launch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 ## emu-launch.sh
 

--- a/tools/emu-launch.sh
+++ b/tools/emu-launch.sh
@@ -30,7 +30,7 @@ getFlatpak () {
         echo "Error: Flatpak not found." >> "${LOGFILE}"
         return 1
     else
-        EMUPATH=("/usr/bin/flatpak" "run" "${FLATPAK}")
+        EMUPATH=("flatpak" "run" "${FLATPAK}")
     fi
 }
 

--- a/tools/launchers/ares-emu.sh
+++ b/tools/launchers/ares-emu.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
+
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 cd $biosPath

--- a/tools/launchers/ares-emu.sh
+++ b/tools/launchers/ares-emu.sh
@@ -6,6 +6,6 @@ git pull
 launcherInit
 cd $biosPath
 emulatorInit "ares"
-/usr/bin/flatpak run dev.ares.ares "${@}"
+flatpak run dev.ares.ares "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/azahar.sh
+++ b/tools/launchers/azahar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/bigpemu.sh
+++ b/tools/launchers/bigpemu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/cemu-native.sh
+++ b/tools/launchers/cemu-native.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/cemu.sh
+++ b/tools/launchers/cemu.sh
@@ -177,10 +177,10 @@ main () {
         checkFile "${CEMU}"
 
         # APPID
-        if [ -e "/usr/bin/python" ]; then
-            APPID=$( /usr/bin/python "${APPIDPY}" "${EXE}" "${NAME}" )
-        elif [ -e "/usr/bin/python3" ]; then
-            APPID=$( /usr/bin/python3 "${APPIDPY}" "${EXE}" "${NAME}" )
+        if command -v python &>/dev/null; then
+            APPID=$( python "${APPIDPY}" "${EXE}" "${NAME}" )
+        elif command -v python3 &>/dev/null; then
+            APPID=$( python3 "${APPIDPY}" "${EXE}" "${NAME}" )
         else 
             echo "Python not found."
         fi

--- a/tools/launchers/cemu.sh
+++ b/tools/launchers/cemu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
@@ -161,7 +161,7 @@ main () {
         CONFIG_FILE="${SELFPATH}.config"
 
         # Get EXE
-        EXE="\"/usr/bin/bash\" \"${SELFPATH}\""
+        EXE="\"/usr/bin/env bash\" \"${SELFPATH}\""
         echo "EXE: ${EXE}"
 
         # AppID.py

--- a/tools/launchers/cemu.sh
+++ b/tools/launchers/cemu.sh
@@ -62,7 +62,7 @@ getFlatpak () {
         echo "Error: Flatpak not found."
         return 1
     else
-        EMUPATH=("/usr/bin/flatpak" "run" "${FLATPAK}")
+        EMUPATH=("flatpak" "run" "${FLATPAK}")
     fi
 }
 

--- a/tools/launchers/citron.sh
+++ b/tools/launchers/citron.sh
@@ -12,8 +12,8 @@ appimage=$(find "$emusFolder" -iname "${emuName}*.AppImage" -print -quit 2>/dev/
 
 # if appimage doesn't exist fall back to flatpak
 if [[ -z "$appimage" ]]; then
-	flatpakApp=$(/usr/bin/flatpak list --app --columns=application | grep -im1 "${emuName}")
-	set -- /usr/bin/flatpak run "$flatpakApp" "$@"
+	flatpakApp=$(flatpak list --app --columns=application | grep -im1 "${emuName}")
+	set -- flatpak run "$flatpakApp" "$@"
 else
 	# make sure the appimage is executable
 	chmod +x "$appimage"

--- a/tools/launchers/citron.sh
+++ b/tools/launchers/citron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 emuName="citron" #parameterize me
 
 cd "$HOME/.config/EmuDeck/backend/"

--- a/tools/launchers/dolphin-emu.sh
+++ b/tools/launchers/dolphin-emu.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "dolphin" "${@}"
-/usr/bin/flatpak run org.DolphinEmu.dolphin-emu "${@}"
+flatpak run org.DolphinEmu.dolphin-emu "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/dolphin-emu.sh
+++ b/tools/launchers/dolphin-emu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/duckstation.sh
+++ b/tools/launchers/duckstation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/eden.sh
+++ b/tools/launchers/eden.sh
@@ -12,8 +12,8 @@ appimage=$(find "$emusFolder" -iname "${emuName}*.AppImage" -print -quit 2>/dev/
 
 # if appimage doesn't exist fall back to flatpak
 if [[ -z "$appimage" ]]; then
-	flatpakApp=$(/usr/bin/flatpak list --app --columns=application | grep -im1 "${emuName}")
-	set -- /usr/bin/flatpak run "$flatpakApp" "$@"
+	flatpakApp=$(flatpak list --app --columns=application | grep -im1 "${emuName}")
+	set -- flatpak run "$flatpakApp" "$@"
 else
 	# make sure the appimage is executable
 	chmod +x "$appimage"

--- a/tools/launchers/eden.sh
+++ b/tools/launchers/eden.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 emuName="eden" #parameterize me
 
 cd "$HOME/.config/EmuDeck/backend/"

--- a/tools/launchers/es-de/es-de.sh
+++ b/tools/launchers/es-de/es-de.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/flycast.sh
+++ b/tools/launchers/flycast.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "flycast"
-/usr/bin/flatpak run org.flycast.Flycast "${@}"
+flatpak run org.flycast.Flycast "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/flycast.sh
+++ b/tools/launchers/flycast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/mame.sh
+++ b/tools/launchers/mame.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "mame"
-/usr/bin/flatpak run org.mamedev.MAME "${@}"
+flatpak run org.mamedev.MAME "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/mame.sh
+++ b/tools/launchers/mame.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/melonds.sh
+++ b/tools/launchers/melonds.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "melonds"
-/usr/bin/flatpak run net.kuribo64.melonDS "${@}"
+flatpak run net.kuribo64.melonDS "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/melonds.sh
+++ b/tools/launchers/melonds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/mgba.sh
+++ b/tools/launchers/mgba.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/model-2-emulator.sh
+++ b/tools/launchers/model-2-emulator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
@@ -11,7 +11,7 @@ SELFPATH="$( realpath "${BASH_SOURCE[0]}" )"
 CONFIG_FILE="${SELFPATH}.config"
 
 # Get EXE
-EXE="\"/usr/bin/bash\" \"${SELFPATH}\""
+EXE="\"/usr/bin/env bash\" \"${SELFPATH}\""
 
 # NAME
 NAME="Model2Emu"

--- a/tools/launchers/model-2-emulator.sh
+++ b/tools/launchers/model-2-emulator.sh
@@ -34,10 +34,10 @@ else
 fi
 
 # APPID
-if [ -e "/usr/bin/python" ]; then
-    APPID=$( /usr/bin/python "${APPIDPY}" "${EXE}" "${NAME}" )
-elif [ -e "/usr/bin/python3" ]; then
-    APPID=$( /usr/bin/python3 "${APPIDPY}" "${EXE}" "${NAME}" )
+if command -v python &>/dev/null; then
+    APPID=$( python "${APPIDPY}" "${EXE}" "${NAME}" )
+elif command -v python3 &>/dev/null; then
+    APPID=$( python3 "${APPIDPY}" "${EXE}" "${NAME}" )
 else
     echo "Python not found."
 fi

--- a/tools/launchers/pcsx2-qt.sh
+++ b/tools/launchers/pcsx2-qt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/pegasus/pegasus-frontend.sh
+++ b/tools/launchers/pegasus/pegasus-frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/ppsspp.sh
+++ b/tools/launchers/ppsspp.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "ppsspp"
-/usr/bin/flatpak run org.ppsspp.PPSSPP "${@}"
+flatpak run org.ppsspp.PPSSPP "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/ppsspp.sh
+++ b/tools/launchers/ppsspp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/primehack.sh
+++ b/tools/launchers/primehack.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "primehack"
-/usr/bin/flatpak run io.github.shiiion.primehack "${@}"
+flatpak run io.github.shiiion.primehack "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/primehack.sh
+++ b/tools/launchers/primehack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/retroarch.sh
+++ b/tools/launchers/retroarch.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "retroarch"
-/usr/bin/flatpak run org.libretro.RetroArch $netplayCMD "${@}"
+flatpak run org.libretro.RetroArch $netplayCMD "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/retroarch.sh
+++ b/tools/launchers/retroarch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/rosaliesmupengui.sh
+++ b/tools/launchers/rosaliesmupengui.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "RMG"
-/usr/bin/flatpak run com.github.Rosalie241.RMG "${@}"
+flatpak run com.github.Rosalie241.RMG "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/rosaliesmupengui.sh
+++ b/tools/launchers/rosaliesmupengui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/rpcs3.sh
+++ b/tools/launchers/rpcs3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/ryujinx.sh
+++ b/tools/launchers/ryujinx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/scummvm.sh
+++ b/tools/launchers/scummvm.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "scummvm"
-/usr/bin/flatpak run org.scummvm.ScummVM "${@}"
+flatpak run org.scummvm.ScummVM "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/scummvm.sh
+++ b/tools/launchers/scummvm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/shadps4.sh
+++ b/tools/launchers/shadps4.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/srm/steamrommanager.sh
+++ b/tools/launchers/srm/steamrommanager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/supermodel.sh
+++ b/tools/launchers/supermodel.sh
@@ -6,6 +6,6 @@ launcherInit
 emulatorInit "supermodel"
 param="${@}"
 param=$(echo "$param" | sed "s|'||g")
-/usr/bin/flatpak run com.supermodel3.Supermodel "${param}"
+flatpak run com.supermodel3.Supermodel "${param}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming";

--- a/tools/launchers/vita3k.sh
+++ b/tools/launchers/vita3k.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/xemu-emu.sh
+++ b/tools/launchers/xemu-emu.sh
@@ -4,6 +4,6 @@ git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"
 launcherInit
 emulatorInit "xemu"
-/usr/bin/flatpak run app.xemu.xemu "${@}"
+flatpak run app.xemu.xemu "${@}"
 cloud_sync_uploadForced
 rm -rf "$savesPath/.gaming"; 

--- a/tools/launchers/xemu-emu.sh
+++ b/tools/launchers/xemu-emu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/xenia.sh
+++ b/tools/launchers/xenia.sh
@@ -27,10 +27,10 @@ PROTONLAUNCH="${toolsPath}/proton-launch.sh"
 XENIA="$romsPath/xbox360/xenia_canary.exe"
 
 # APPID
-if [ -e "/usr/bin/python" ]; then
-    APPID=$( /usr/bin/python "${APPIDPY}" "${EXE}" "${NAME}" )
-elif [ -e "/usr/bin/python3" ]; then
-    APPID=$( /usr/bin/python3 "${APPIDPY}" "${EXE}" "${NAME}" )
+if command -v python &>/dev/null; then
+    APPID=$( python "${APPIDPY}" "${EXE}" "${NAME}" )
+elif command -v python3 &>/dev/null; then
+    APPID=$( python3 "${APPIDPY}" "${EXE}" "${NAME}" )
 else 
     echo "Python not found."
 fi

--- a/tools/launchers/xenia.sh
+++ b/tools/launchers/xenia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # xenia.sh
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
@@ -12,7 +12,7 @@ SELFPATH="$( realpath "${BASH_SOURCE[0]}" )"
 CONFIG_FILE="${SELFPATH}.config"
 
 # Get EXE
-EXE="\"/usr/bin/bash\" \"${SELFPATH}\""
+EXE="\"/usr/bin/env bash\" \"${SELFPATH}\""
 
 # NAME
 NAME="Xenia"

--- a/tools/launchers/xeniaNative.sh
+++ b/tools/launchers/xeniaNative.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/launchers/yuzu.sh
+++ b/tools/launchers/yuzu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.config/EmuDeck/backend/"
 git pull
 . "$HOME/.config/EmuDeck/backend/functions/all.sh"

--- a/tools/proton-launch.sh
+++ b/tools/proton-launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## proton-launch.sh
 

--- a/tools/proton-launch.sh
+++ b/tools/proton-launch.sh
@@ -269,10 +269,10 @@ main () {
     set_env
 
     # Start application with Proton
-    if [ -e "/usr/bin/python" ]; then
+    if command -v python &>/dev/null; then
         echo "Running python ${PROTON} waitforexitandrun ${*}" >> "${LOGFILE}" # Send command to log just in case
         python "${PROTON}" waitforexitandrun "${@}"
-    elif [ -e "/usr/bin/python3" ]; then
+    elif command -v python3 &>/dev/null; then
         echo "Running python ${PROTON} waitforexitandrun ${*}" >> "${LOGFILE}" # Send command to log just in case
         python3 "${PROTON}" waitforexitandrun "${@}"
     else 


### PR DESCRIPTION
This PR improves the launcher scripts portability on linux distributions that don't follow the FHS, i.e. distributions where the programs are not in `/usr/bin` such as NixOS.

On NixOS, my bash is currently at:
```
/nix/store/cgjr3kj3hs7ngznyws5qfg16c8scpys0-bash-interactive-5.3p9/bin/bash
```

This PR makes the launchers use the `PATH` through standard idioms, instead of the hardcoded paths.
The 3 impacted binary calls are :
- `bash` (the shebang)
- `python/python3`
- `flatpak`