### PR TITLE
feat: add recursive iteration for psx bios folder

### DIFF
--- a/functions/checkBIOS.sh
+++ b/functions/checkBIOS.sh
@@ -4,7 +4,7 @@ checkPS1BIOS(){
 
 	PSXBIOS="NULL"
 
-	for entry in "$biosPath/"*
+	for entry in "$biosPath/"* "$biosPath/ps1/"*
 	do
 		if [ -f "$entry" ]; then
 			md5=($(md5sum "$entry"))
@@ -37,7 +37,7 @@ checkPS2BIOS(){
 
 	PS2BIOS="NULL"
 
-	for entry in "$biosPath/"*
+	for entry in "$biosPath/"* "$biosPath/ps2/"*
 	do
 		if [ -f "$entry" ]; then
 			md5=($(md5sum "$entry"))


### PR DESCRIPTION
# Description
Allow the bios for ps1 and ps2 to be under it's own folder to avoid being loose (this is mainly for ps2 bios, I just added ps1 for standardization).

# Showcase
**Organized**
<img width="3276" height="1051" alt="imagen" src="https://github.com/user-attachments/assets/aa6be746-8f84-4205-ace3-40600826e64d" />

**Tons of loose files for ps2 bios inside it's own folder**
<img width="1468" height="1014" alt="imagen" src="https://github.com/user-attachments/assets/418671da-2bd6-467c-bf85-30d5c87f8e0d" />
